### PR TITLE
Support source map files with absolute paths in the debugger

### DIFF
--- a/src/SourceMaps.ts
+++ b/src/SourceMaps.ts
@@ -118,9 +118,6 @@ class SourceMapCache {
 					if (!this._generatedSourcePathToMapLookup.has(generatedSourceRelativePath)) {
 						this._generatedSourcePathToMapLookup.set(generatedSourceRelativePath, mapInfo);
 					}
-					else {
-						console.log('Index are getting off here');
-					}
 				}
 			}
 		}
@@ -195,6 +192,15 @@ export class SourceMaps {
 			bias: SourceMapConsumer.LEAST_UPPER_BOUND
 		});
 
+		if (generatedPosition.line === null) {
+			generatedPosition = mapInfo.sourceMap.generatedPositionFor({
+				source: mapInfo.preferAbsolute ? mapInfo.sourceAbsolutePath : mapInfo.originalSourceRelativePath,
+				line: originalPosition.line,
+				column: originalPosition.column,
+				bias: SourceMapConsumer.GREATEST_LOWER_BOUND
+			});
+		}
+
 		return generatedPosition;
 	}
 
@@ -213,6 +219,14 @@ export class SourceMaps {
 				line: generatedPosition.line,
 				bias: SourceMapConsumer.LEAST_UPPER_BOUND
 			});
+
+			if (originalPos.line === null) {
+				originalPos = mapInfo.sourceMap.originalPositionFor({
+					line: generatedPosition.line,
+					column: generatedPosition.column,
+					bias: SourceMapConsumer.GREATEST_LOWER_BOUND
+				});
+			}
 
 			if (originalPos.line !== null && originalPos.column !== null && originalPos.source !== null) {
 				// combine directory of map and relative path from map to .ts to arrive at absolute path of .ts


### PR DESCRIPTION
When source map files are moved (such as when generating a bundle in one location and then deploying it elsewhere), relative paths won't work as expected. In these cases, source maps can be configured using [absolute-resource-path] in their file name template, and the minecraft-debugger should be able to handle these cases.

I also added fallback logic for the bias when getting the generated line number.