### PR TITLE
localRoot must point directly to js files, not pack root. Warn user if no sources found at set location.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,3 +23,7 @@
 ## Version 0.4.0 (August 2022)
 
 - Add support for source maps that contain absolute paths.
+
+## Version 0.4.2 (September 2022)
+
+- Changes to the source path location in Minecraft require that localRoot points to a directory with sources, not the pack root. Update your launch.json 'localRoot'.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "minecraft-debugger",
 	"displayName": "Minecraft Bedrock Edition Debugger",
 	"description": "Debug your JavaScript code running as part of the GameTest Framework experimental feature in Minecraft Bedrock Edition.",
-	"version": "0.4.1",
+	"version": "0.4.2",
 	"publisher": "mojang-studios",
 	"author": {
 		"name": "Mojang Studios"
@@ -61,8 +61,8 @@
 							},
 							"localRoot": {
 								"type": "string",
-								"description": "The local root of the Minecraft Add-On.",
-								"default": "${workspaceFolder}/"
+								"description": "The local root of the Minecraft Add-On scripts folder.",
+								"default": "${workspaceFolder}/scripts"
 							},
 							"sourceMapRoot": {
 								"type": "string",

--- a/src/ConfigProvider.ts
+++ b/src/ConfigProvider.ts
@@ -21,7 +21,7 @@ export class ConfigProvider implements vscode.DebugConfigurationProvider {
 			config.name = 'Attach to Minecraft';
 		}
 		if (!config.localRoot) {
-			config.localRoot = "${workspaceFolder}/";
+			config.localRoot = "${workspaceFolder}/scripts/";
 		}
 		if (!config.port) {
 			config.inputPort = "${command:PromptForPort}"; // prompt user for port

--- a/src/Session.ts
+++ b/src/Session.ts
@@ -9,6 +9,7 @@ import { MessageStreamParser } from './MessageStreamParser';
 import { SourceMaps } from './SourceMaps';
 import { FileSystemWatcher, window, workspace } from 'vscode';
 import * as path from 'path';
+import * as fs from 'fs';
 
 interface PendingResponse {
 	resolve: Function;
@@ -42,6 +43,9 @@ export class Session extends DebugSession {
 	private _sourceMaps: SourceMaps = new SourceMaps("");
 	private _fileWatcher?: FileSystemWatcher;
 	private _activeThreadId: number = 0;	// the one being debugged
+	private _localRoot: string = "";
+	private _sourceMapRoot?: string;	
+	private _generatedSourceRoot?: string;
 
 	public constructor() {
 		super();
@@ -81,6 +85,10 @@ export class Session extends DebugSession {
 			return;
 		}
 
+		this._localRoot = args.localRoot ? path.normalize(args.localRoot) : "";
+		this._sourceMapRoot = args.sourceMapRoot ? path.normalize(args.sourceMapRoot) : undefined;
+		this._generatedSourceRoot = args.generatedSourceRoot ? path.normalize(args.generatedSourceRoot) : undefined;
+
 		// Listen or connect (default), depending on mode.
 		// Attach makes more sense to use connect, but some MC platforms require using listen.
 		try {
@@ -96,13 +104,7 @@ export class Session extends DebugSession {
 			return;
 		}
 
-		// init source maps
-		this._sourceMaps = new SourceMaps(args.localRoot, args.sourceMapRoot, args.generatedSourceRoot);
-
-		// watch for source map changes
-		this.createSourceMapFileWatcher(args.sourceMapRoot);
-
-		// tell VSCode that attach is complete
+		// tell VSCode that attach has been received
 		this.sendResponse(response);
 	}
 
@@ -357,9 +359,22 @@ export class Session extends DebugSession {
 		// connect socket to stream parser
 		socket.pipe(socketStreamParser as any);
 
+		//
+		// Now wait for the debugee protocol event which will call onConnectionComplete if accepted.
+		//
+	}
+
+	private onConnectionComplete() {
+		// success
 		this.showNotification("Success! Debugger is now connected.", LogLevel.Log);
 
-		// Now that a connection is established, send this event to
+		// init source maps
+		this._sourceMaps = new SourceMaps(this._localRoot, this._sourceMapRoot, this._generatedSourceRoot);
+
+		// watch for source map changes
+		this.createSourceMapFileWatcher(this._sourceMapRoot);
+		
+		// Now that a connection is established, and capabilities have been delivered, send this event to
 		// tell VSCode to ask Minecraft/debugee for config data (breakpoints etc).
 		// When config is complete VSCode calls 'configurationDoneRequest' and the DA
 		// sends a 'resume' message to the debugee, which had paused following the attach.
@@ -498,18 +513,42 @@ export class Session extends DebugSession {
 
 	// ------------------------------------------------------------------------
 
-	private handleProtocolEvent(eventMessage: any) {
-		let mcVer = eventMessage.version;
-		let extVer = Session.DEBUGGER_PROTOCOL_VERSION;
-		if (mcVer < extVer) {
-			// Minecraft protocol is behind the extension
-			let errorMessage = `Minecraft's debugger protocol [${mcVer}] is not compatible with this extension's protocol [${extVer}], please update Minecraft.`;
-			this.showNotification(errorMessage, LogLevel.Error);
+	private handleProtocolEvent(protocolCapabilities: any) {
+		//
+		// handle protocol capabilities here...
+		// can fail connection on errors
+		//
+
+		// MC isn't using pack root, check that localRoot is pointing to js files
+		if (protocolCapabilities.disablePackRoot) {
+			this.handleCapabilityDisablePackRoot(); // warn but don't fail connection
 		}
-		else if (mcVer > extVer) {
-			// Extension protocol is behind Minecraft
-			let errorMessage = `This extension's protocol [${extVer}] is not compatible with Minecraft's debugger protocol [${mcVer}], please update the extension.`;
-			this.showNotification(errorMessage, LogLevel.Error);
+
+		// success
+		this.onConnectionComplete();
+	}
+
+	// MC source files are rooted to scripts/ folder, not the pack root.
+	// check that the localRoot property of launch.json contains source files.
+	// message to user if no source files are found.
+	private handleCapabilityDisablePackRoot() {
+		let sourcePath = this._sourceMapRoot ? this._sourceMapRoot : this._localRoot;
+		let foundSourceFiles = false;
+		try {
+			let fileNames = fs.readdirSync(sourcePath);
+			for (let fn of fileNames) {
+				let ext = path.extname(fn);
+				if (ext == ".js" || ext == ".ts") {
+					foundSourceFiles = true;
+					break;
+				}
+			}
+		}
+		catch (e) {
+		}
+		
+		if (!foundSourceFiles) {
+			this.showNotification("Failed to find source files. Check that launch.json 'localRoot' contains scripts.", LogLevel.Warn);
 		}
 	}
 

--- a/src/SourceMaps.ts
+++ b/src/SourceMaps.ts
@@ -2,9 +2,9 @@
 // Copyright (C) Microsoft Corporation.  All rights reserved.
 
 import { BasicSourceMapConsumer, MappedPosition, NullablePosition, SourceMapConsumer } from 'source-map';
+import { normalizePath, normalizePathForRemote } from './Utils';
 import * as fs from 'fs';
 import * as path from 'path';
-import { normalizePath, normalizePathForRemote, removeRemotePathPrefix, addRemotePathPrefix } from './Utils';
 
 interface MapInfo {
 	mapAbsoluteDirectory: string			// full path to parent folder of map file, needed when combining with relative paths within map
@@ -169,8 +169,7 @@ export class SourceMaps {
 		}
 
 		// given absolute path to generated source, convert to a remote relative path the debugger understands
-		let generatedRemoteRelativePath = addRemotePathPrefix(mapInfo.generatedSourceRelativePath);
-		return normalizePathForRemote(generatedRemoteRelativePath);
+		return normalizePathForRemote(mapInfo.generatedSourceRelativePath);
 	}
 
 	public async getGeneratedPositionFor(originalPosition: MappedPosition): Promise<NullablePosition> {
@@ -212,7 +211,7 @@ export class SourceMaps {
 			return originalLocalRelativePosition;
 		}
 
-		let mapInfo = await this._sourceMapCache.getMapFromGeneratedSource(removeRemotePathPrefix(generatedPosition.source));
+		let mapInfo = await this._sourceMapCache.getMapFromGeneratedSource(generatedPosition.source);
 		if (mapInfo) {
 			let originalPos = mapInfo.sourceMap.originalPositionFor({
 				column: generatedPosition.column,

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -34,16 +34,3 @@ export function normalizePathForRemote(filePath: string) {
 	// remote debugger expects forward slashes on all platforms
 	return filePath.replace(/\\/g,"/");
 }
-
-// TODO: remove this after fixing internal root path of MC scripts
-export function removeRemotePathPrefix(filePath: string) {
-    // remove the required "/scripts/" prefix from the generated sources when coming back from debugger
-    return filePath.split('/').slice(1).join('/');
-}
-
-// TODO: remove this
-export function addRemotePathPrefix(filePath: string) {
-     const REMOTE_SOURCE_PATH_PREFIX = "scripts";
-    // required to prepend "/scripts/" to generated sources for remote debugger
-    return path.join(REMOTE_SOURCE_PATH_PREFIX, filePath);
-}


### PR DESCRIPTION
MC script source files are now rooted to the /scripts folder, not the pack. This means that the debugger's localRoot must also point to /scripts. 

- Send VSCode "initialized" event only after MC sends protocol packet.
- Updated the default localRoot to include /scripts
- Add warning if no sources files found at localRoot, with messaging to update it.
- Remove add/remove scripts prefix hack from sourcemaps