### PR TITLE
Add support for module name mapping and unknown source files in stack trace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,3 +27,7 @@
 ## Version 0.5.0 (September 2022)
 
 - Changes to the source path location in Minecraft require that localRoot points to a directory with sources, not the pack root. Update your launch.json 'localRoot'.
+
+## Version 0.6.0 (September 2022)
+
+- Add support for external modules while debugging. For JS modules built into Minecraft, stack will be visible but listed as "unknown". Add configuration support for module name mapping.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "minecraft-debugger",
-	"version": "0.1.2",
+	"version": "0.5.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "minecraft-debugger",
-			"version": "0.1.2",
+			"version": "0.5.0",
 			"license": "MIT",
 			"dependencies": {
 				"source-map": "^0.7.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "minecraft-debugger",
-	"version": "0.5.0",
+	"version": "0.6.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "minecraft-debugger",
-			"version": "0.5.0",
+			"version": "0.6.0",
 			"license": "MIT",
 			"dependencies": {
 				"source-map": "^0.7.3",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "minecraft-debugger",
 	"displayName": "Minecraft Bedrock Edition Debugger",
 	"description": "Debug your JavaScript code running as part of the GameTest Framework experimental feature in Minecraft Bedrock Edition.",
-	"version": "0.5.0",
+	"version": "0.6.0",
 	"publisher": "mojang-studios",
 	"author": {
 		"name": "Mojang Studios"
@@ -87,7 +87,7 @@
 							},
 							"moduleMapping": {
 								"type": "object",
-								"description": "Module mapping for imports. Used if modules are external (i.e. included as part of minecraft). Defaults to an empty object."
+								"description": "Module mapping for imports. Each key is an import name that will be mapped to the provided value. Used if modules are external (i.e. included as part of minecraft). Defaults to an empty object."
 							}
 						}
 					}

--- a/package.json
+++ b/package.json
@@ -84,6 +84,10 @@
 							"inputPort": {
 								"type": "string",
 								"description": "Prompts for a port at launch."
+							},
+							"moduleMapping": {
+								"type": "object",
+								"description": "Module mapping for imports. Used if modules are external (i.e. included as part of minecraft). Defaults to an empty object."
 							}
 						}
 					}


### PR DESCRIPTION
There may be JS loaded into a minecraft JS runtime that an extension creator may not have access to. In these cases, it is still important to be able to debug a creators extension code, while external code should be treated as unknown in the callstack.

For internal development, to allow source map debugging, module name mapping can be used to map a module name to a local file. This is a new parameter in the launch configuration to support this.