### PR TITLE
add inlineSourceMap arg, parse paths starting with %appdata%, misc bug fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "minecraft-debugger",
-	"version": "0.6.0",
+	"version": "0.6.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "minecraft-debugger",
-			"version": "0.6.0",
+			"version": "0.6.1",
 			"license": "MIT",
 			"dependencies": {
 				"source-map": "^0.7.3",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
 							},
 							"inlineSourceMap": {
 								"type": "boolean",
-								"description": "If true, generated source maps will be searched for in the generated source files.",
+								"description": "Whether or not source maps are embedded in the generated source files. Overrides sourceMapRoot and generatedSourceRoot when true.",
 								"default": false
 							},
 							"host": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,11 @@
 								"type": "string",
 								"description": "The location of the generated source files (js). Not required if same as source maps."
 							},
+							"inlineSourceMap": {
+								"type": "boolean",
+								"description": "If true, generated source maps will be searched for in the generated source files.",
+								"default": false
+							},
 							"host": {
 								"type": "string",
 								"description": "The host address the extension will connect to.",

--- a/src/Session.ts
+++ b/src/Session.ts
@@ -88,11 +88,11 @@ export class Session extends DebugSession {
 		this.closeSession();
 
 		// for each arg, if the value is a string and starts with %localappdata%, replace it with the actual path to appdata/local
-		const localAppDataDir = process.env.APPDATA?.replace('Roaming', 'Local') || '';
+		const localAppDataDir = process.env.LOCALAPPDATA || '';
 		for (const key of Object.keys(args)) {
 			let value = args[key as keyof IAttachRequestArguments];
 			if (typeof value === 'string' && value.toLowerCase().startsWith('%localappdata%')) {
-				(args as any)[key] = value.replace('%localappdata%', localAppDataDir);
+				(args as any)[key] = path.join(localAppDataDir, value.substring('%localappdata%'.length));
 			}
 		}
 			

--- a/src/Session.ts
+++ b/src/Session.ts
@@ -87,12 +87,12 @@ export class Session extends DebugSession {
 	protected async attachRequest(response: DebugProtocol.AttachResponse, args: IAttachRequestArguments, request?: DebugProtocol.Request) {
 		this.closeSession();
 
-		// for each arg, if the value is a string and starts with %appdata%, replace it with the actual path to appdata/local
-		const appDataLocalDir = process.env.APPDATA?.replace('Roaming', 'Local') || '';
+		// for each arg, if the value is a string and starts with %localappdata%, replace it with the actual path to appdata/local
+		const localAppDataDir = process.env.APPDATA?.replace('Roaming', 'Local') || '';
 		for (const key of Object.keys(args)) {
 			let value = args[key as keyof IAttachRequestArguments];
-			if (typeof value === 'string' && value.startsWith('%appdata%')) {
-				(args as any)[key] = value.replace('%appdata%', appDataLocalDir);
+			if (typeof value === 'string' && value.startsWith('%localappdata%')) {
+				(args as any)[key] = value.replace('%localappdata%', localAppDataDir);
 			}
 		}
 			

--- a/src/Session.ts
+++ b/src/Session.ts
@@ -91,7 +91,7 @@ export class Session extends DebugSession {
 		const localAppDataDir = process.env.APPDATA?.replace('Roaming', 'Local') || '';
 		for (const key of Object.keys(args)) {
 			let value = args[key as keyof IAttachRequestArguments];
-			if (typeof value === 'string' && value.startsWith('%localappdata%')) {
+			if (typeof value === 'string' && value.toLowerCase().startsWith('%localappdata%')) {
 				(args as any)[key] = value.replace('%localappdata%', localAppDataDir);
 			}
 		}

--- a/src/SourceMaps.ts
+++ b/src/SourceMaps.ts
@@ -87,8 +87,7 @@ class SourceMapCache {
 				if (this._inlineSourceMap) {
 					const inlineSourceMapRegex = /\/\/# sourceMappingURL=data:application\/json;base64,(.*)$/gm;
 					const match = inlineSourceMapRegex.exec(mapFile.toString());
-					let sourceRoot;
-					sourceRoot = path.join(this._localRoot ?? '', path.dirname(mapFileName.split('\\scripts\\')[1]));
+					const sourceRoot = path.join(this._localRoot ?? '', path.dirname(mapFileName.split('\\scripts\\')[1]));
 					if (match && match.length > 1) {
 						const base64EncodedMap = match[1];
 						const decodedMap = Buffer.from(base64EncodedMap, 'base64').toString('utf8');

--- a/src/SourceMaps.ts
+++ b/src/SourceMaps.ts
@@ -34,15 +34,20 @@ class MapLookup {
 // Load and cache source map files
 class SourceMapCache {
 	private static readonly _mapFileExt: string = ".map";
+	private static readonly _jsFileExt: string = ".js";
 	private _sourceMapRoot?: string;
 	public _generatedSourceRoot?: string;
+	private _localRoot?: string;
 	private _mapsLoaded: boolean = false;
 	public _originalSourcePathToMapLookup = new MapLookup();
 	public _generatedSourcePathToMapLookup = new MapLookup();
+	private _inlineSourceMap: boolean = false;
 
-	public constructor(sourceMapRoot?: string, generatedSourceRoot?: string) {
+	public constructor(sourceMapRoot?: string, generatedSourceRoot?: string, inlineSourceMap: boolean = false, localRoot?: string) {
 		this._sourceMapRoot = (sourceMapRoot) ? path.normalize(sourceMapRoot) : undefined;
 		this._generatedSourceRoot = (generatedSourceRoot) ? path.normalize(generatedSourceRoot) : undefined;
+		this._inlineSourceMap = inlineSourceMap;
+		this._localRoot = (localRoot) ? path.normalize(localRoot) : undefined;
 	}
 
 	public reset() {
@@ -67,17 +72,36 @@ class SourceMapCache {
 		}
 
 		// assume generated js files live with map files unless explicitly set otherwise
-		if (this._generatedSourceRoot == undefined) {
+		if (this._generatedSourceRoot === undefined) {
 			this._generatedSourceRoot = this._sourceMapRoot;
 		}
 
 		try {
-			const mapFileNames = this._findAllMapFilesInFolder(this._sourceMapRoot, undefined);
+			const mapFileNames = this._findAllMapFilesInFolder(this._sourceMapRoot, undefined, this._inlineSourceMap ? SourceMapCache._jsFileExt : SourceMapCache._mapFileExt);
 			for (let mapFileName of mapFileNames) {
 
-				const mapFullPath = path.resolve(this._sourceMapRoot, mapFileName);
-				let mapBuffer = fs.readFileSync(mapFullPath);
-				let mapJson = JSON.parse(mapBuffer.toString());
+				const mapFullPath = path.resolve(this._sourceMapRoot, mapFileName);				
+				let mapFile = fs.readFileSync(mapFullPath);
+
+				let mapJson;
+				if (this._inlineSourceMap) {
+					const inlineSourceMapRegex = /\/\/# sourceMappingURL=data:application\/json;base64,(.*)$/gm;
+					const match = inlineSourceMapRegex.exec(mapFile.toString());
+					let sourceRoot;
+					sourceRoot = path.join(this._localRoot ?? '', path.dirname(mapFileName.split('\\scripts\\')[1]));
+					if (match && match.length > 1) {
+						const base64EncodedMap = match[1];
+						const decodedMap = Buffer.from(base64EncodedMap, 'base64').toString('utf8');
+						mapJson = JSON.parse(decodedMap);
+						mapJson.file = path.basename(mapFileName);
+						mapJson.sourceRoot = sourceRoot;
+					} else {
+						throw new Error('Could not find inline source map');
+					}
+				} else {
+					mapJson = JSON.parse(mapFile.toString());
+				}
+				
 				let sourceMapConsumer = await new SourceMapConsumer(mapJson);
 
 				// map has relative path to generated source, resolve for absolute path
@@ -128,15 +152,15 @@ class SourceMapCache {
 		this._mapsLoaded = true;
 	}
 
-	private _findAllMapFilesInFolder(dirPath: string, existingFiles?: Array<string>): Array<string> {
+	private _findAllMapFilesInFolder(dirPath: string, existingFiles?: Array<string>, fileExtentsion: string = SourceMapCache._mapFileExt): Array<string> {
 		let fileNames = fs.readdirSync(dirPath);
 		let allFiles = existingFiles || [];
 		fileNames.forEach((file) => {
 			const fullPath = path.join(dirPath, file);
 			if (fs.statSync(fullPath).isDirectory()) {
-				allFiles = this._findAllMapFilesInFolder(fullPath, allFiles);
+				allFiles = this._findAllMapFilesInFolder(fullPath, allFiles, fileExtentsion);
 		  	}
-		  	else if (path.extname(file) === SourceMapCache._mapFileExt) {
+		  	else if (path.extname(file) === fileExtentsion) {
 				allFiles.push(fullPath);
 		  	}
 		});
@@ -150,11 +174,13 @@ export class SourceMaps {
 	private _localRoot: string;
 	private _sourceMapRoot?: string;
 	private _sourceMapCache: SourceMapCache;
+	private _inlineSourceMap: boolean;
 
-	public constructor(localRoot: string, sourceMapRoot?: string, generatedSourceRoot?: string) {
+	public constructor(localRoot: string, sourceMapRoot?: string, generatedSourceRoot?: string, inlineSourceMap: boolean = false) {
 		this._localRoot = path.normalize(localRoot);
 		this._sourceMapRoot = (sourceMapRoot) ? path.normalize(sourceMapRoot) : undefined;
-		this._sourceMapCache = new SourceMapCache(this._sourceMapRoot, generatedSourceRoot);
+		this._sourceMapCache = new SourceMapCache(this._sourceMapRoot, generatedSourceRoot, inlineSourceMap, localRoot);
+		this._inlineSourceMap = inlineSourceMap;
 	}
 
 	public reset() {
@@ -180,7 +206,7 @@ export class SourceMaps {
 				line: originalPosition.line,
 				column: originalPosition.column,
 				lastColumn: null
-			}
+			};
 		}
 
 		// use the map to get the generated source (js) position using original source path (a relative path to the map)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,8 +2,8 @@
 // Copyright (C) Microsoft Corporation.  All rights reserved.
 
 import * as vscode from 'vscode';
-import { ConfigProvider } from './ConfigProvider'
-import { ServerDebugAdapterFactory } from './ServerDebugAdapterFactory'
+import { ConfigProvider } from './ConfigProvider';
+import { ServerDebugAdapterFactory } from './ServerDebugAdapterFactory';
 
 // called when extension is activated
 //


### PR DESCRIPTION
# Features
- Added new boolean config argument: `inlineSourceMap`. If set to true, TS sourcemaps will be searched through within the outputted JS files.
- - This will add support to [Bridge.](https://github.com/bridge-core/editor), which uses the [Dash compiler](https://github.com/bridge-core/dash-compiler) for compilation, that uses SWC's [wasm-web](https://www.npmjs.com/package/@swc/wasm-web) package for TS transpiration, which can only output inline source-maps.
- Directory paths within config arguments starting with `%localappdata%` (not case-sensitive) will now be replaced with the path to the user's `AppData/Local` directory.
- - This will enable having directory paths to `com.mojang` that aren't restricted to one user.

# Fixes
- Having directories or other irrelevant within the outputted scripts folder that alphabetically precede JS files will no longer cause errors.
- - `Session` Class's `doFilesWithExtExistAt` method only looked at the first entry in the outputted scripts directory.
- Misc. formatting fixes