### PR TITLE
Add "All Exceptions" toggle to breakpoints panel to optionally enable breaking at exceptions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,3 +39,7 @@
 ## Version 0.7.0 (March 2023)
 
 - Support for inline source maps. Paths with %appdata% will be replaced with user app data folder.
+
+## Version 0.8.0 (April 2023)
+
+- Add "All Exceptions" option to breakpoints panel, enabling will instruct Minecraft to break at exceptions.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "minecraft-debugger",
 	"displayName": "Minecraft Bedrock Edition Debugger",
 	"description": "Debug your JavaScript code running as part of the GameTest Framework experimental feature in Minecraft Bedrock Edition.",
-	"version": "0.7.0",
+	"version": "0.8.0",
 	"publisher": "mojang-studios",
 	"author": {
 		"name": "Mojang Studios"

--- a/src/Session.ts
+++ b/src/Session.ts
@@ -69,10 +69,18 @@ export class Session extends DebugSession {
 
 	// VSCode extension has been activated due to the 'onDebug' activation request defined in packages.json
 	protected initializeRequest(response: DebugProtocol.InitializeResponse, args: DebugProtocol.InitializeRequestArguments): void {
-		response.body = response.body || {};
+		const capabilities: DebugProtocol.Capabilities = {
+			// indicates VSCode should send the configurationDoneRequest
+			supportsConfigurationDoneRequest: true,
+			// additional breakpoint filter options shown in UI
+			exceptionBreakpointFilters: [{
+				filter: "exceptions",
+				label: "All Exceptions",
+				default: false
+			}]
+		}
 
-		// set capabilities
-		response.body.supportsConfigurationDoneRequest = true; // so VSCode calls 'configurationDoneRequest'
+		response.body = capabilities;
 
 		// send config response back to VSCode
 		this.sendResponse(response);
@@ -133,7 +141,6 @@ export class Session extends DebugSession {
 		}
 	}
 
-
 	protected async setBreakPointsRequest(response: DebugProtocol.SetBreakpointsResponse, args: DebugProtocol.SetBreakpointsArguments, request?: DebugProtocol.Request) {
 		response.body = {
 			breakpoints: []
@@ -188,7 +195,11 @@ export class Session extends DebugSession {
 	}
 
 	protected setExceptionBreakPointsRequest(response: DebugProtocol.SetExceptionBreakpointsResponse, args: DebugProtocol.SetExceptionBreakpointsArguments, request?: DebugProtocol.Request): void {
-		// todo: to make this work set the exceptionBreakpointFilters capability at init, then send result to debugee here
+		this.sendDebuggeeMessage({
+			type: 'stopOnException',
+			stopOnException: args.filters.length > 0 // there's only 1 type for now so no need to look at which one it is
+		});
+
 		this.sendResponse(response);
 	}
 


### PR DESCRIPTION
Set capability for breakpoint filters at init, enabling the `setExceptionBreakPointsRequest`, which then communicates the option to the debugee (MC).