### PR TITLE
Add stat tree visualizer panel for displaying MC script memory usage.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,3 +55,7 @@
 ## Version 1.1.1 (September 2023)
 
 - Handle uncaught exceptions during .map file discovery against invalid directory. Write to log and pop notification message.
+
+## Version 1.2.0 (September 2023)
+
+- Add 'Minecraft Diagnostics' panel to debugger view. Display script memory stats.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "minecraft-debugger",
-	"version": "1.1.2",
+	"version": "1.2.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "minecraft-debugger",
-			"version": "1.1.2",
+			"version": "1.2.0",
 			"license": "MIT",
 			"dependencies": {
 				"source-map": "^0.7.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1449,20 +1449,6 @@
 			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
 			"dev": true
 		},
-		"node_modules/fsevents": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-			"dev": true,
-			"hasInstallScript": true,
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-			}
-		},
 		"node_modules/function-bind": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -4501,13 +4487,6 @@
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
 			"dev": true
-		},
-		"fsevents": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-			"dev": true,
-			"optional": true
 		},
 		"function-bind": {
 			"version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "minecraft-debugger",
 	"displayName": "Minecraft Bedrock Edition Debugger",
 	"description": "Debug your JavaScript code running in Minecraft Bedrock Edition.",
-	"version": "1.1.2",
+	"version": "1.2.0",
 	"publisher": "mojang-studios",
 	"author": {
 		"name": "Mojang Studios"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "minecraft-debugger",
 	"displayName": "Minecraft Bedrock Edition Debugger",
-	"description": "Debug your JavaScript code running as part of the GameTest Framework experimental feature in Minecraft Bedrock Edition.",
+	"description": "Debug your JavaScript code running in Minecraft Bedrock Edition.",
 	"version": "1.1.2",
 	"publisher": "mojang-studios",
 	"author": {
@@ -34,6 +34,15 @@
 	],
 	"main": "./out/extension.js",
 	"contributes": {
+		"views": {
+			"debug": [
+				{
+					"type": "tree",
+					"id": "MinecraftStatsTreeDataProvider",
+					"name": "Minecraft Diagnostics"
+				}
+			]
+		},
 		"breakpoints": [
 			{
 				"language": "javascript"

--- a/src/ServerDebugAdapterFactory.ts
+++ b/src/ServerDebugAdapterFactory.ts
@@ -4,6 +4,7 @@
 import * as Net from 'net';
 import * as vscode from 'vscode';
 import { Session } from './Session';
+import { StatsProvider } from './StatsProvider';
 
 // Factory for creating a Debug Adapter that runs as a server inside the extension and communicates via a socket.
 //
@@ -11,11 +12,13 @@ export class ServerDebugAdapterFactory implements vscode.DebugAdapterDescriptorF
 
 	private server?: Net.Server;
 
+	constructor(private _statProvider: StatsProvider) {}
+
 	createDebugAdapterDescriptor(session: vscode.DebugSession, executable: vscode.DebugAdapterExecutable | undefined): vscode.ProviderResult<vscode.DebugAdapterDescriptor> {
 		if (!this.server) {
 			// start listening on a random port
 			this.server = Net.createServer(socket => {
-				const session = new Session();
+				const session = new Session(this._statProvider);
 				session.setRunAsServer(true);
 				session.start(socket as NodeJS.ReadableStream, socket);
 			}).listen(0);

--- a/src/Session.ts
+++ b/src/Session.ts
@@ -8,6 +8,7 @@ import { LogOutputEvent, LogLevel } from 'vscode-debugadapter/lib/logger';
 import { MessageStreamParser } from './MessageStreamParser';
 import { SourceMaps } from './SourceMaps';
 import { FileSystemWatcher, window, workspace } from 'vscode';
+import { StatsProvider } from './StatsProvider';
 import * as path from 'path';
 import * as fs from 'fs';
 
@@ -56,7 +57,7 @@ export class Session extends DebugSession {
 	private _inlineSourceMap: boolean = false;
 	private _moduleMapping?: ModuleMapping;
 
-	public constructor() {
+	public constructor(private _statsProvider: StatsProvider) {
 		super();
 
 		this.setDebuggerLinesStartAt1(true);
@@ -545,6 +546,9 @@ export class Session extends DebugSession {
 		}
 		else if (eventMessage.type === 'ProtocolEvent') {
 			this.handleProtocolEvent(eventMessage);
+		}
+		else if (eventMessage.type == 'StatEvent') {
+			this._statsProvider.setStats(eventMessage.stats);
 		}
 	}
 

--- a/src/StatsProvider.ts
+++ b/src/StatsProvider.ts
@@ -63,22 +63,22 @@ export class StatsProvider implements vscode.TreeDataProvider<StatTreeItem> {
 
 	public setStats(stats: any) {
 		this._statMap.clear();
-			stats?.forEach((stat: StatData) => {
-				if (!stat.parent_id) {
-					if (!this._statMap.has(this._rootKey)) {
-						this._statMap.set(this._rootKey, []);
-					}
-					let rootStats = this._statMap.get(this._rootKey);
-					rootStats?.push(stat);
+		stats?.forEach((stat: StatData) => {
+			if (!stat.parent_id) {
+				if (!this._statMap.has(this._rootKey)) {
+					this._statMap.set(this._rootKey, []);
 				}
-				else {
-					if (!this._statMap.has(stat.parent_id)) {
-						this._statMap.set(stat.parent_id, []);
-					}
-					let parentStats = this._statMap.get(stat.parent_id);
-					parentStats?.push(stat);
+				let rootStats = this._statMap.get(this._rootKey);
+				rootStats?.push(stat);
+			}
+			else {
+				if (!this._statMap.has(stat.parent_id)) {
+					this._statMap.set(stat.parent_id, []);
 				}
-			});
+				let parentStats = this._statMap.get(stat.parent_id);
+				parentStats?.push(stat);
+			}
+		});
 		this._onDidChangeTreeData.fire();
 	}
 

--- a/src/StatsProvider.ts
+++ b/src/StatsProvider.ts
@@ -1,0 +1,99 @@
+import * as vscode from 'vscode';
+
+export class StatTreeItem extends vscode.TreeItem {
+
+	constructor(
+		public readonly label: string,
+		public readonly collapsibleState: vscode.TreeItemCollapsibleState,
+		id: string | undefined
+	) {
+		super(label, collapsibleState);        
+		this.id = id; // provide base a stable id because label can change
+	}
+}
+
+interface StatData {
+	id: string;
+	parent_id: string;
+	type: string;
+	label: string;
+	value: string;
+}
+
+export class StatsProvider implements vscode.TreeDataProvider<StatTreeItem> {
+		
+	public static readonly viewId = 'MinecraftStatsTreeDataProvider';
+
+	private _onDidChangeTreeData: vscode.EventEmitter<StatTreeItem | undefined | void> = new vscode.EventEmitter<StatTreeItem | undefined | void>();
+	readonly onDidChangeTreeData: vscode.Event<StatTreeItem | undefined | void> = this._onDidChangeTreeData.event;
+
+	private readonly _rootKey: string = "__root__";
+	private _statMap: Map<string, Array<StatData>> = new Map<string, Array<StatData>>();
+
+	// from TreeDataProvider interface
+	public getTreeItem(element: StatTreeItem): vscode.TreeItem | Thenable<vscode.TreeItem> {
+		return element;
+	}
+
+	// from TreeDataProvider interface
+	public getChildren(element?: StatTreeItem | undefined): vscode.ProviderResult<StatTreeItem[]> {
+		const statTreeItems: StatTreeItem[] = [];
+		if (this._statMap) {
+			if (element == null) {
+				let rootStats = this._statMap.get(this._rootKey);
+				if (rootStats) {
+					rootStats.forEach((stat: StatData) => {
+						const label = this._toStatLabel(stat);
+						statTreeItems.push(new StatTreeItem(label, this._collapsibleState(stat), stat.id));
+					});
+				}
+			}
+			else {
+				let childStats = this._statMap.get(element.id||"");
+				if (childStats) {
+					childStats.forEach((stat: StatData) => {
+						const label = this._toStatLabel(stat);
+						statTreeItems.push(new StatTreeItem(label, this._collapsibleState(stat), stat.id));
+					});
+				}
+			}
+		}
+		return Promise.resolve(statTreeItems);
+	}
+
+	public setStats(stats: any) {
+		this._statMap.clear();
+			stats?.forEach((stat: StatData) => {
+				if (!stat.parent_id) {
+					if (!this._statMap.has(this._rootKey)) {
+						this._statMap.set(this._rootKey, []);
+					}
+					let rootStats = this._statMap.get(this._rootKey);
+					rootStats?.push(stat);
+				}
+				else {
+					if (!this._statMap.has(stat.parent_id)) {
+						this._statMap.set(stat.parent_id, []);
+					}
+					let parentStats = this._statMap.get(stat.parent_id);
+					parentStats?.push(stat);
+				}
+			});
+		this._onDidChangeTreeData.fire();
+	}
+
+	private _toStatLabel(stat: StatData): string {
+		if (stat.type === "memorySize" && stat.value) {
+			let intVal = 0;
+			if (typeof stat.value === 'string') {
+				intVal = parseInt(stat.value, 10);
+			}
+			return stat.label + ": " + (intVal / 1000).toFixed(2) + "  KB"; // show in KB (todo: add user option to display as MB)
+		}
+		return stat.label + (stat.value || "");
+	}
+
+	private _collapsibleState(stat: StatData): vscode.TreeItemCollapsibleState {
+		return this._statMap.has(stat.id) ? vscode.TreeItemCollapsibleState.Collapsed : vscode.TreeItemCollapsibleState.None;
+	}
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,25 +4,34 @@
 import * as vscode from 'vscode';
 import { ConfigProvider } from './ConfigProvider';
 import { ServerDebugAdapterFactory } from './ServerDebugAdapterFactory';
+import { StatsProvider } from './StatsProvider';
 
 // called when extension is activated
 //
 export function activate(context: vscode.ExtensionContext) {
 
+	// create tree data providers and register them
+	const statsTreeDataProvider = new StatsProvider();
+	context.subscriptions.push(
+		vscode.window.registerTreeDataProvider(StatsProvider.viewId, statsTreeDataProvider)
+	);
+
 	// register commands
-	context.subscriptions.push(vscode.commands.registerCommand('extension.minecraft-js.getPort', config => {
-		return vscode.window.showInputBox({
-			placeHolder: "Please enter the port Minecraft is listening on.",
-			value: ""
-		});
-	}));
+	context.subscriptions.push(
+		vscode.commands.registerCommand('extension.minecraft-js.getPort', config => {
+			return vscode.window.showInputBox({
+				placeHolder: "Please enter the port Minecraft is listening on.",
+				value: ""
+			});
+		})
+	);
 
 	// register a configuration provider for the 'minecraft-js' debug type
 	const configProvider = new ConfigProvider();
 	context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider("minecraft-js", configProvider));
 
 	// register a debug adapter descriptor factory for 'minecraft-js', this factory creates the DebugSession
-	let descriptorFactory = new ServerDebugAdapterFactory();
+	let descriptorFactory = new ServerDebugAdapterFactory(statsTreeDataProvider);
 	context.subscriptions.push(vscode.debug.registerDebugAdapterDescriptorFactory('minecraft-js', descriptorFactory));
 
 	if ('dispose' in descriptorFactory) {


### PR DESCRIPTION
Minecraft can push generic "stats" to VSCode, which will display them in tree hierarchy format in the debug panel.