### PR TITLE
Handle uncaught exception during .map file discovery.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,3 +51,7 @@
 ## Version 1.1.0 (June 2023)
 
 - Fix ignored 'stop' event, which caused missing variables and stack frame.
+
+## Version 1.1.1 (September 2023)
+
+- Handle uncaught exceptions during .map file discovery against invalid directory. Write to log and pop notification message.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "minecraft-debugger",
 	"displayName": "Minecraft Bedrock Edition Debugger",
 	"description": "Debug your JavaScript code running as part of the GameTest Framework experimental feature in Minecraft Bedrock Edition.",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"publisher": "mojang-studios",
 	"author": {
 		"name": "Mojang Studios"

--- a/src/Session.ts
+++ b/src/Session.ts
@@ -615,11 +615,16 @@ export class Session extends DebugSession {
 		if (!filePath || !extensions) {
 			return false;
 		}
-		let fileNames = fs.readdirSync(filePath);
-		for (let fn of fileNames) {
-			if (extensions.some(ext => fn.endsWith(ext))) {
-				return true;
+		try {
+			let fileNames = fs.readdirSync(filePath);
+			for (let fn of fileNames) {
+				if (extensions.some(ext => fn.endsWith(ext))) {
+					return true;
+				}
 			}
+		}
+		catch (e) {
+			this.log((e as Error).message, LogLevel.Error);
 		}
 		return false;
 	}


### PR DESCRIPTION
If the sourceMapFolder is set but doesn't exist on disk it will throw during discovery. This disrupts the connection handshake and leaves MC waiting for a 'resume' that never arrives.  

Catch the exception, log the error and pop a notification to the user to check their source map folder names.