### PR TITLE
Expose sourceMapBias config parameter to help fix breakpoint alignment issues between source ts and generated js for certain configurations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,3 +59,7 @@
 ## Version 1.2.0 (September 2023)
 
 - Add 'Minecraft Diagnostics' panel to debugger view. Display script memory stats.
+
+## Version 1.3.0 (February 2024)
+
+- Expose source map lookup bias parameter "sourceMapBias" to the launch config to account for variations in how source maps are generated. Changing this from the default can fix breakpoint line number alignment issues between original source (ts) and generated source (js). Defaults to "leastUpperBound" and can be changed to "greatestLowerBound".

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
 	"name": "minecraft-debugger",
-	"version": "1.2.1",
+	"version": "1.3.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "minecraft-debugger",
-			"version": "1.2.1",
+			"version": "1.3.0",
 			"license": "MIT",
 			"dependencies": {
-				"source-map": "^0.7.3",
+				"source-map": "^0.7.4",
 				"stream-parser": "^0.3.1",
 				"vscode-debugadapter": "1.47.0"
 			},

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "minecraft-debugger",
 	"displayName": "Minecraft Bedrock Edition Debugger",
 	"description": "Debug your JavaScript code running in Minecraft Bedrock Edition.",
-	"version": "1.2.1",
+	"version": "1.3.0",
 	"publisher": "mojang-studios",
 	"author": {
 		"name": "Mojang Studios"
@@ -103,6 +103,10 @@
 							"moduleMapping": {
 								"type": "object",
 								"description": "Module mapping for imports. Each key is an import name that will be mapped to the provided value. Used if modules are external (i.e. included as part of minecraft). Defaults to an empty object."
+							},
+							"sourceMapBias": {
+								"type": "string",
+								"description": "The bias to use when mapping from generated code to source code. Can be either 'leastUpperBound' or 'greatestLowerBound'. Defaults to 'leastUpperBound'."
 							}
 						}
 					}
@@ -148,7 +152,7 @@
 		"package": "vsce package -o minecraft-debugger-js.vsix"
 	},
 	"dependencies": {
-		"source-map": "^0.7.3",
+		"source-map": "^0.7.4",
 		"stream-parser": "^0.3.1",
 		"vscode-debugadapter": "1.47.0"
 	},

--- a/src/Session.ts
+++ b/src/Session.ts
@@ -34,6 +34,7 @@ interface IAttachRequestArguments extends DebugProtocol.AttachRequestArguments {
 	port: number;
 	inputPort: string;
 	moduleMapping: ModuleMapping;
+	sourceMapBias: string;
 }
 
 // The Debug Adapter for 'minecraft-js'
@@ -56,6 +57,7 @@ export class Session extends DebugSession {
 	private _generatedSourceRoot?: string;
 	private _inlineSourceMap: boolean = false;
 	private _moduleMapping?: ModuleMapping;
+	private _sourceMapBias?: string;
 
 	public constructor(private _statsProvider: StatsProvider) {
 		super();
@@ -110,6 +112,7 @@ export class Session extends DebugSession {
 		this._generatedSourceRoot = args.generatedSourceRoot ? path.normalize(args.generatedSourceRoot) : undefined;
 		this._inlineSourceMap = args.inlineSourceMap ? args.inlineSourceMap : false;
 		this._moduleMapping = args.moduleMapping;
+		this._sourceMapBias = args.sourceMapBias;
 
 		// Listen or connect (default), depending on mode.
 		// Attach makes more sense to use connect, but some MC platforms require using listen.
@@ -411,7 +414,7 @@ export class Session extends DebugSession {
 		this.showNotification("Success! Debugger is now connected.", LogLevel.Log);
 
 		// init source maps
-		this._sourceMaps = new SourceMaps(this._localRoot, this._sourceMapRoot, this._generatedSourceRoot, this._inlineSourceMap);
+		this._sourceMaps = new SourceMaps(this._localRoot, this._sourceMapRoot, this._generatedSourceRoot, this._inlineSourceMap, this._sourceMapBias);
 
 		// watch for source map changes
 		this.createSourceMapFileWatcher(this._sourceMapRoot);


### PR DESCRIPTION
The default source map consumer bias of 'least upper bound' does not work in all configurations. Expose this parameter to the launch config. If the designated bias results in a missing line, the alternate will be used.