### PR TITLE
Remove extra line break in print event, content log adds one from MC.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,3 +63,7 @@
 ## Version 1.3.0 (February 2024)
 
 - Expose source map lookup bias parameter "sourceMapBias" to the launch config to account for variations in how source maps are generated. Changing this from the default can fix breakpoint line number alignment issues between original source (ts) and generated source (js). Defaults to "leastUpperBound" and can be changed to "greatestLowerBound".
+
+## Version 1.3.1 (April 2024)
+
+- Remove extra line break in logs from MC.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "minecraft-debugger",
 	"displayName": "Minecraft Bedrock Edition Debugger",
 	"description": "Debug your JavaScript code running in Minecraft Bedrock Edition.",
-	"version": "1.3.0",
+	"version": "1.3.1",
 	"publisher": "mojang-studios",
 	"author": {
 		"name": "Mojang Studios"

--- a/src/Session.ts
+++ b/src/Session.ts
@@ -545,7 +545,7 @@ export class Session extends DebugSession {
 			this.sendEvent(new ThreadEvent(eventMessage.reason, eventMessage.thread));
 		}
 		else if (eventMessage.type === 'PrintEvent') {
-			this.sendEvent(new LogOutputEvent(eventMessage.message + '\n', eventMessage.logLevel));
+			this.sendEvent(new LogOutputEvent(eventMessage.message, eventMessage.logLevel));
 		}
 		else if (eventMessage.type === 'ProtocolEvent') {
 			this.handleProtocolEvent(eventMessage);


### PR DESCRIPTION
Print events from MC are now all routed through a content log handler, allowing the debugger to be a general purpose content log viewer. Content log handlers add \n to each message, so we don't need to add it on the debugger side.