### PR TITLE
Add targetModuleUuid to launch config to isolate debugger messages to a specific add-on.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,3 +67,7 @@
 ## Version 1.3.1 (April 2024)
 
 - Remove extra line break in logs from MC.
+
+## Version 1.4.0 (May 2024)
+
+- Add targetModuleUuid to launch config, this ensures debugger messages (breakpoints etc) target the correct Minecraft Add-On.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "minecraft-debugger",
 	"displayName": "Minecraft Bedrock Edition Debugger",
 	"description": "Debug your JavaScript code running in Minecraft Bedrock Edition.",
-	"version": "1.3.1",
+	"version": "1.4.0",
 	"publisher": "mojang-studios",
 	"author": {
 		"name": "Mojang Studios"
@@ -107,6 +107,10 @@
 							"sourceMapBias": {
 								"type": "string",
 								"description": "The bias to use when mapping from generated code to source code. Can be either 'leastUpperBound' or 'greatestLowerBound'. Defaults to 'leastUpperBound'."
+							},
+							"targetModuleUuid": {
+								"type": "string",
+								"description": "The script module uuid from the manifest.json of the Minecraft Add-On being debugged. Necessary if there are multiple Add-Ons active."
 							}
 						}
 					}

--- a/src/Session.ts
+++ b/src/Session.ts
@@ -110,7 +110,7 @@ export class Session extends DebugSession {
 			return;
 		}
 
-		if (args.targetModuleUuid === undefined || args.targetModuleUuid === "" || !isUUID(args.targetModuleUuid)) {
+		if (!args.targetModuleUuid || args.targetModuleUuid === "" || !isUUID(args.targetModuleUuid)) {
 			this.showNotification("Launch config module target (targetModuleUuid) is not a valid uuid. This should be set to the script module uuid from your manifest.json. Omitting this may cause problems when multiple Minecraft Add-Ons are active.", LogLevel.Warn);
 		}
 		else {

--- a/src/Session.ts
+++ b/src/Session.ts
@@ -599,11 +599,7 @@ export class Session extends DebugSession {
 		if (Session.DEBUGGER_PROTOCOL_VERSION < protocolCapabilities.version) {
 			this.terminateSession("protocol mismatch. Update Debugger Extension.", LogLevel.Error);
 		}
-		// todo: enable when MC updates with protocol handshake
-		/*else if (Session.DEBUGGER_PROTOCOL_VERSION > protocolCapabilities.version) {
-			this.terminateSession("protocol mismatch. Update Minecraft or roll-back the Debugger Extension.", LogLevel.Error);
-		}*/
-		else {		
+		else {
 			this.sendDebuggeeMessage({
 				type: 'protocol',
 				version: Session.DEBUGGER_PROTOCOL_VERSION,

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -23,7 +23,7 @@ function hasDriveLetter(path: string, isWindowsOS: boolean): boolean {
 	return false;
 }
 
-export function normalizePath(filePath: string): string {	
+export function normalizePath(filePath: string): string {
 	if (hasDriveLetter(filePath, os.type() == 'Windows_NT')) {
 		return path.normalize(filePath.charAt(0).toUpperCase() + filePath.slice(1));
 	}
@@ -36,6 +36,6 @@ export function normalizePathForRemote(filePath: string) {
 }
 
 export function isUUID(uuid: string) {
-	const regex = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$/i;
+	const regex = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/i;
 	return regex.test(uuid);
 }

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -36,6 +36,6 @@ export function normalizePathForRemote(filePath: string) {
 }
 
 export function isUUID(uuid: string) {
-	let regex = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$/i;
+	const regex = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$/i;
 	return regex.test(uuid);
 }

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -34,3 +34,8 @@ export function normalizePathForRemote(filePath: string) {
 	// remote debugger expects forward slashes on all platforms
 	return filePath.replace(/\\/g,"/");
 }
+
+export function isUUID(uuid: string) {
+	let regex = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$/i;
+	return regex.test(uuid);
+}


### PR DESCRIPTION
This change increases the message reliability when multiple add-ons are active in Minecraft. Messages will only be consumed by the add-on indicated by the targetModuleUuid launch parameter. If targetModuleUuid is not defined, a warning will appear on connect.

Given the release cadence differences between the debugger and MC, and the non-breaking protocol change (if MC is lower), protocol handshake will not fail if Debugger version > MC version.  If MC protocol is greater than the debugger, session will terminate with an error indicating the user should update.


