### PR TITLE
Throw error for missing inline source maps

### DIFF
--- a/src/SourceMaps.ts
+++ b/src/SourceMaps.ts
@@ -152,7 +152,9 @@ class SourceMapCache {
 			}
 		}
 		catch (e) {
-			if(e instanceof InlineSourceMapError) throw e;
+			if(e instanceof InlineSourceMapError) { 
+				throw e;
+			}
 			else {
 				throw new Error(`Failed to load source maps at [${this._sourceMapRoot}], check that 'sourceMapRoot' is set correctly.`);
 			}

--- a/src/SourceMaps.ts
+++ b/src/SourceMaps.ts
@@ -15,6 +15,8 @@ interface MapInfo {
 	preferAbsolute: boolean;				// if true, use absolute paths as that is what the source map contained
 }
 
+class InlineSourceMapError extends Error{}
+
 class MapLookup {
 	private _sourceToMapInfo = new Map<string, MapInfo>();
 	public get(sourcePath: string) {
@@ -95,7 +97,7 @@ class SourceMapCache {
 						mapJson.file = path.basename(mapFileName);
 						mapJson.sourceRoot = sourceRoot;
 					} else {
-						throw new Error('Could not find inline source map');
+						throw new InlineSourceMapError(`Failed to load inline source maps for file: ${mapFileName}`);
 					}
 				} else {
 					mapJson = JSON.parse(mapFile.toString());
@@ -106,7 +108,6 @@ class SourceMapCache {
 						mapJson.file = path.basename(mapFileName).replace(SourceMapCache._mapFileExt, '');
 					}
 				}
-				
 				let sourceMapConsumer = await new SourceMapConsumer(mapJson);
 
 				// map has relative path to generated source, resolve for absolute path
@@ -151,7 +152,10 @@ class SourceMapCache {
 			}
 		}
 		catch (e) {
-			throw new Error(`Failed to load source maps at [${this._sourceMapRoot}], check that 'sourceMapRoot' is set correctly.`);
+			if(e instanceof InlineSourceMapError) throw e;
+			else {
+				throw new Error(`Failed to load source maps at [${this._sourceMapRoot}], check that 'sourceMapRoot' is set correctly.`);
+			}
 		}
 
 		this._mapsLoaded = true;


### PR DESCRIPTION
## Fixes
This resolves an issue where, when using inline sourcemaps, if a JS file does not contain an inline source map, `_loadSourceMaps` throws a vague error about the path of `sourceMapRoot`. It now throws an error including the file name that did not have inline source maps.

Old:
![image](https://github.com/Mojang/minecraft-debugger/assets/84604286/2efa4e76-3d9c-4ae6-bb04-8b7d1f87c8fa)
New: 
![image](https://github.com/Mojang/minecraft-debugger/assets/84604286/61948383-c2bc-4fa4-96ed-21950a23e2b6)


