### PR TITLE
Make log messages clearer by displaying a relative source path

### DIFF
--- a/src/Session.ts
+++ b/src/Session.ts
@@ -638,12 +638,12 @@ export class Session extends DebugSession {
                     line: javaScriptLineNumber,
                 });
                 //Resolve generatedPosition.source to be relative to the active workspace. If there is no workspace, it will be the absolute path.
-                const generatedPositionSourceRelative = workspace.asRelativePath(generatedPosition.source);
+                const generatedPositionSourceAsRelative = workspace.asRelativePath(generatedPosition.source);
 
                 if (generatedPosition) {
                     message = message.replace(
                         fullMatch,
-                        `(${generatedPositionSourceRelative}:${generatedPosition.line}) (${javaScriptFilePath}:${javaScriptLineNumber})`
+                        `(${generatedPositionSourceAsRelative}:${generatedPosition.line}) (${javaScriptFilePath}:${javaScriptLineNumber})`
                     );
                 }
             } catch (e) {

--- a/src/Session.ts
+++ b/src/Session.ts
@@ -637,8 +637,11 @@ export class Session extends DebugSession {
                     column: 0,
                     line: javaScriptLineNumber,
                 });
-                //Resolve generatedPosition.source to be relative to the active workspace. If there is no workspace, it will be the absolute path.
-                const generatedPositionSourceAsRelative = workspace.asRelativePath(generatedPosition.source);
+                // Resolve generatedPosition.source to be relative to the active workspace. If there is no workspace, the absolute path gets returned.
+                let generatedPositionSourceAsRelative = workspace.asRelativePath(generatedPosition.source);
+                if (generatedPositionSourceAsRelative !== generatedPosition.source) {
+                    generatedPositionSourceAsRelative = `./${generatedPositionSourceAsRelative}`;
+                }
 
                 if (generatedPosition) {
                     message = message.replace(

--- a/src/Session.ts
+++ b/src/Session.ts
@@ -637,11 +637,13 @@ export class Session extends DebugSession {
                     column: 0,
                     line: javaScriptLineNumber,
                 });
+                //Resolve generatedPosition.source to be relative to the active workspace. If there is no workspace, it will be the absolute path.
+                const generatedPositionSourceRelative = workspace.asRelativePath(generatedPosition.source);
 
                 if (generatedPosition) {
                     message = message.replace(
                         fullMatch,
-                        `(${generatedPosition.source}:${generatedPosition.line}) (${javaScriptFilePath}:${javaScriptLineNumber})`
+                        `(${generatedPositionSourceRelative}:${generatedPosition.line}) (${javaScriptFilePath}:${javaScriptLineNumber})`
                     );
                 }
             } catch (e) {


### PR DESCRIPTION
- Make log messages slightly clearer by displaying the generated source position relative to the workspace. 
  - If there isn't a workspace the absolute path will still be used.

Before:
![image](https://github.com/Mojang/minecraft-debugger/assets/84604286/b22e7a4c-65d9-4e98-b99c-b498436278a5)
After:
![image](https://github.com/Mojang/minecraft-debugger/assets/84604286/a26c8fdf-43fd-4bf6-bf8a-ce4f7406fea3)
