### PR TITLE
Updated CSP to allow in-line styling for diagnostics pane that uses Observable Plot

### DIFF
--- a/src/panels/MinecraftDiagnostics.ts
+++ b/src/panels/MinecraftDiagnostics.ts
@@ -131,7 +131,7 @@ export class MinecraftDiagnosticsPanel {
         <head>
           <meta charset="UTF-8" />
           <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-          <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webview.cspSource}; script-src 'nonce-${nonce}';">
+          <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webview.cspSource} 'unsafe-inline'; script-src 'nonce-${nonce}';">
           <link rel="stylesheet" type="text/css" href="${stylesUri}">
           <title>Minecraft Diagnostics</title>
         </head>


### PR DESCRIPTION
We've secretly (or not so secretly if you've looked at the web dev tool console) been hitting CSP errors due to Observable Plot's in-line styling.

A [thread about it exists](https://www.linen.dev/s/observable-community/t/18844234/topic) and there isn't a clear work around that is scalable and maintains full CSP protection so this change selectively allows in-line styling for this page.

Now our legends can finally be formatted nicely!

Before:
![image](https://github.com/Mojang/minecraft-debugger/assets/1000311/6d638d2c-4c60-4567-a8cd-1325c28f7a80)

After:
![image](https://github.com/Mojang/minecraft-debugger/assets/1000311/86927c5b-d809-44b8-a8f2-9f66deecd0f0)

