### PR TITLE
Add styling for diagnostics pane that uses Observable Plot to CSS file

### DIFF
--- a/webview-ui/src/diagnostics_panel/App.css
+++ b/webview-ui/src/diagnostics_panel/App.css
@@ -23,22 +23,22 @@ main {
   margin-bottom: 2px;
 }
 
-.plot-d6a7b5-swatches {
+[class^='plot-'][class$='-swatches'] {
   font-family: system-ui, sans-serif;
   font-size: 10px;
   margin-bottom: 0.5em;
 }
-.plot-d6a7b5-swatch > svg {
+[class^='plot-'][class$='-swatch'] > svg {
   margin-right: 0.5em;
   overflow: visible;
 }
-.plot-d6a7b5-swatches-wrap {
+[class^='plot-'][class$='-swatches-wrap'] {
   display: flex;
   align-items: center;
   min-height: 33px;
   flex-wrap: wrap;
 }
-.plot-d6a7b5-swatches-wrap .plot-d6a7b5-swatch {
+[class^='plot-'][class$='-swatches-wrap'] [class^='plot-'][class$='-swatch'] {
   display: inline-flex;
   align-items: center;
   margin-right: 1em;

--- a/webview-ui/src/diagnostics_panel/App.css
+++ b/webview-ui/src/diagnostics_panel/App.css
@@ -41,7 +41,7 @@ main {
 .minecraft-statistic-stacked-line-chart-swatches-wrap {
   display: flex;
   align-items: center;
-  min-height: 33px;
+  /* min-height: 33px; */
   flex-wrap: wrap;
 }
 
@@ -81,7 +81,7 @@ main {
 .minecraft-statistic-stacked-bar-chart-swatches-wrap {
   display: flex;
   align-items: center;
-  min-height: 33px;
+  /* min-height: 33px; */
   flex-wrap: wrap;
 }
 

--- a/webview-ui/src/diagnostics_panel/App.css
+++ b/webview-ui/src/diagnostics_panel/App.css
@@ -23,22 +23,22 @@ main {
   margin-bottom: 2px;
 }
 
-[class^='plot-'][class$='-swatches'] {
+.minecraft-statistic-stacked-line-chart-swatches {
   font-family: system-ui, sans-serif;
   font-size: 10px;
   margin-bottom: 0.5em;
 }
-[class^='plot-'][class$='-swatch'] > svg {
+.minecraft-statistic-stacked-line-chart-swatch > svg {
   margin-right: 0.5em;
   overflow: visible;
 }
-[class^='plot-'][class$='-swatches-wrap'] {
+.minecraft-statistic-stacked-line-chart-swatches-wrap {
   display: flex;
   align-items: center;
   min-height: 33px;
   flex-wrap: wrap;
 }
-[class^='plot-'][class$='-swatches-wrap'] [class^='plot-'][class$='-swatch'] {
+.minecraft-statistic-stacked-line-chart-swatches-wrap .minecraft-statistic-stacked-line-chart-swatch {
   display: inline-flex;
   align-items: center;
   margin-right: 1em;

--- a/webview-ui/src/diagnostics_panel/App.css
+++ b/webview-ui/src/diagnostics_panel/App.css
@@ -22,3 +22,24 @@ main {
   line-height: normal;
   margin-bottom: 2px;
 }
+
+.plot-d6a7b5-swatches {
+  font-family: system-ui, sans-serif;
+  font-size: 10px;
+  margin-bottom: 0.5em;
+}
+.plot-d6a7b5-swatch > svg {
+  margin-right: 0.5em;
+  overflow: visible;
+}
+.plot-d6a7b5-swatches-wrap {
+  display: flex;
+  align-items: center;
+  min-height: 33px;
+  flex-wrap: wrap;
+}
+.plot-d6a7b5-swatches-wrap .plot-d6a7b5-swatch {
+  display: inline-flex;
+  align-items: center;
+  margin-right: 1em;
+}

--- a/webview-ui/src/diagnostics_panel/App.css
+++ b/webview-ui/src/diagnostics_panel/App.css
@@ -23,13 +23,17 @@ main {
   margin-bottom: 2px;
 }
 
+.minecraft-statistic-stacked-line-chart-figure {
+  max-width: initial;
+}
+
 .minecraft-statistic-stacked-line-chart-swatches {
   font-family: system-ui, sans-serif;
   font-size: 10px;
   margin-bottom: 0.5em;
 }
 
-.minecraft-statistic-stacked-line-chart-swatch > svg {
+.minecraft-statistic-stacked-line-chart-swatch>svg {
   margin-right: 0.5em;
   overflow: visible;
 }
@@ -46,3 +50,135 @@ main {
   align-items: center;
   margin-right: 1em;
 }
+
+/* .minecraft-statistic-stacked-line-chart {
+  --plot-background: white;
+  display: block;
+  height: auto;
+  height: intrinsic;
+  max-width: 100%;
+} */
+
+/* .minecraft-statistic-stacked-line-chart text .minecraft-statistic-stacked-line-chart tspan {
+  white-space: pre;
+} */
+
+.minecraft-statistic-stacked-bar-chart-figure {
+  max-width: initial;
+}
+
+.minecraft-statistic-stacked-bar-chart-swatches {
+  font-family: system-ui, sans-serif;
+  font-size: 10px;
+  margin-bottom: 0.5em;
+}
+
+.minecraft-statistic-stacked-bar-chart-swatch>svg {
+  margin-right: 0.5em;
+  overflow: visible;
+}
+
+.minecraft-statistic-stacked-bar-chart-swatches-wrap {
+  display: flex;
+  align-items: center;
+  min-height: 33px;
+  flex-wrap: wrap;
+}
+
+.minecraft-statistic-stacked-bar-chart-swatches-wrap .minecraft-statistic-stacked-bar-chart-swatch {
+  display: inline-flex;
+  align-items: center;
+  margin-right: 1em;
+}
+
+/* .minecraft-statistic-stacked-bar-chart {
+  --plot-background: white;
+  display: block;
+  height: auto;
+  height: intrinsic;
+  max-width: 100%;
+} */
+
+/* .minecraft-statistic-stacked-bar-chart text .minecraft-statistic-stacked-bar-chart tspan {
+  white-space: pre;
+} */
+
+.line-chart-figure {
+  max-width: initial;
+}
+
+.line-chart-swatches {
+  font-family: system-ui, sans-serif;
+  font-size: 10px;
+  margin-bottom: 0.5em;
+}
+
+.line-chart-swatch>svg {
+  margin-right: 0.5em;
+  overflow: visible;
+}
+
+.line-chart-swatches-wrap {
+  display: flex;
+  align-items: center;
+  min-height: 33px;
+  flex-wrap: wrap;
+}
+
+.line-chart-swatches-wrap .line-chart-swatch {
+  display: inline-flex;
+  align-items: center;
+  margin-right: 1em;
+}
+
+/* .line-chart {
+  --plot-background: white;
+  display: block;
+  height: auto;
+  height: intrinsic;
+  max-width: 100%;
+} */
+
+/* .line-chart text .line-chart tspan {
+  white-space: pre;
+} */
+
+.difference-chart-figure {
+  max-width: initial;
+}
+
+.difference-chart-swatches {
+  font-family: system-ui, sans-serif;
+  font-size: 10px;
+  margin-bottom: 0.5em;
+}
+
+.difference-chart-swatch>svg {
+  margin-right: 0.5em;
+  overflow: visible;
+}
+
+.difference-chart-swatches-wrap {
+  display: flex;
+  align-items: center;
+  min-height: 33px;
+  flex-wrap: wrap;
+}
+
+.difference-chart-swatches-wrap .difference-chart-swatch {
+  display: inline-flex;
+  align-items: center;
+  margin-right: 1em;
+}
+
+/* .difference-chart {
+  --plot-background: white;
+  display: block;
+  height: auto;
+  height: intrinsic;
+  max-width: 100%;
+} */
+
+/* .difference-chart text .difference-chart tspan {
+  white-space: pre;
+} */

--- a/webview-ui/src/diagnostics_panel/App.css
+++ b/webview-ui/src/diagnostics_panel/App.css
@@ -107,30 +107,6 @@ main {
   max-width: initial;
 }
 
-.line-chart-swatches {
-  font-family: system-ui, sans-serif;
-  font-size: 10px;
-  margin-bottom: 0.5em;
-}
-
-.line-chart-swatch>svg {
-  margin-right: 0.5em;
-  overflow: visible;
-}
-
-.line-chart-swatches-wrap {
-  display: flex;
-  align-items: center;
-  min-height: 33px;
-  flex-wrap: wrap;
-}
-
-.line-chart-swatches-wrap .line-chart-swatch {
-  display: inline-flex;
-  align-items: center;
-  margin-right: 1em;
-}
-
 /* .line-chart {
   --plot-background: white;
   display: block;
@@ -145,30 +121,6 @@ main {
 
 .difference-chart-figure {
   max-width: initial;
-}
-
-.difference-chart-swatches {
-  font-family: system-ui, sans-serif;
-  font-size: 10px;
-  margin-bottom: 0.5em;
-}
-
-.difference-chart-swatch>svg {
-  margin-right: 0.5em;
-  overflow: visible;
-}
-
-.difference-chart-swatches-wrap {
-  display: flex;
-  align-items: center;
-  min-height: 33px;
-  flex-wrap: wrap;
-}
-
-.difference-chart-swatches-wrap .difference-chart-swatch {
-  display: inline-flex;
-  align-items: center;
-  margin-right: 1em;
 }
 
 /* .difference-chart {

--- a/webview-ui/src/diagnostics_panel/App.css
+++ b/webview-ui/src/diagnostics_panel/App.css
@@ -28,16 +28,19 @@ main {
   font-size: 10px;
   margin-bottom: 0.5em;
 }
+
 .minecraft-statistic-stacked-line-chart-swatch > svg {
   margin-right: 0.5em;
   overflow: visible;
 }
+
 .minecraft-statistic-stacked-line-chart-swatches-wrap {
   display: flex;
   align-items: center;
   min-height: 33px;
   flex-wrap: wrap;
 }
+
 .minecraft-statistic-stacked-line-chart-swatches-wrap .minecraft-statistic-stacked-line-chart-swatch {
   display: inline-flex;
   align-items: center;

--- a/webview-ui/src/diagnostics_panel/controls/LineChart/LineChart.tsx
+++ b/webview-ui/src/diagnostics_panel/controls/LineChart/LineChart.tsx
@@ -62,6 +62,7 @@ export function LineChart({ title, yLabel, xLabel, statisticOptions, statisticDa
 
         const generateLineChart = (enableFilledChart: boolean): PlotResult => {
             return Plot.plot({
+                className: 'line-chart',
                 title: title,
                 marginLeft: 50, // Y Axis labels were getting cut off
                 x: {
@@ -114,6 +115,7 @@ export function LineChart({ title, yLabel, xLabel, statisticOptions, statisticDa
                 //negativeFill: "blue",
                 tip: true,
             }).plot({
+                className: 'difference-chart',
                 title: title,
                 marginLeft: 50, // Y Axis labels were getting cut off
                 x: {
@@ -153,6 +155,17 @@ export function LineChart({ title, yLabel, xLabel, statisticOptions, statisticDa
         }
 
         if (plot !== undefined && containerRef.current) {
+            const styleElement = plot.querySelector('style');
+            const styleAttribute = plot.getAttributeNode('style');
+
+            if (styleElement !== null) {
+                styleElement.parentNode?.removeChild(styleElement);
+            }
+
+            if (styleAttribute !== null) {
+                plot.removeAttributeNode(styleAttribute);
+            }
+
             containerRef.current.append(plot);
         }
 

--- a/webview-ui/src/diagnostics_panel/controls/MinecraftStatisticStackedBarChart.tsx
+++ b/webview-ui/src/diagnostics_panel/controls/MinecraftStatisticStackedBarChart.tsx
@@ -47,6 +47,7 @@ export default function MinecraftStatisticStackedBarChart({
         const latestTime = data.length !== 0 ? data[data.length - 1].time : 0;
 
         const plot = Plot.plot({
+            className: 'minecraft-statistic-stacked-bar-chart',
             color: {
                 legend: true,
                 tickFormat: d => {
@@ -79,6 +80,32 @@ export default function MinecraftStatisticStackedBarChart({
                 Plot.ruleY([0]),
             ],
         });
+
+        // Remove all style elements and attributes
+        const styleElement = plot.querySelector('style');
+        const svgElements = plot.querySelectorAll('svg');
+        const styleAttribute = plot.getAttributeNode('style');
+
+        if (styleElement !== null) {
+            styleElement.parentNode?.removeChild(styleElement);
+        }
+
+        for (const svgElement of svgElements) {
+            const svgStyleElement = svgElement.querySelector('style');
+            const svgImageElement = svgElement.querySelector('image');
+
+            if (svgStyleElement !== null) {
+                svgStyleElement.parentNode?.removeChild(svgStyleElement);
+            }
+
+            if (svgImageElement !== null) {
+                svgImageElement.parentNode?.removeChild(svgImageElement);
+            }
+        }
+
+        if (styleAttribute !== null) {
+            plot.removeAttributeNode(styleAttribute);
+        }
 
         if (containerRef.current !== null) {
             containerRef.current.append(plot);

--- a/webview-ui/src/diagnostics_panel/controls/MinecraftStatisticStackedBarChart.tsx
+++ b/webview-ui/src/diagnostics_panel/controls/MinecraftStatisticStackedBarChart.tsx
@@ -50,6 +50,8 @@ export default function MinecraftStatisticStackedBarChart({
             className: 'minecraft-statistic-stacked-bar-chart',
             color: {
                 legend: true,
+                type: 'ordinal',
+                scheme: 'Observable10',
                 tickFormat: d => {
                     return d;
                 },
@@ -92,14 +94,9 @@ export default function MinecraftStatisticStackedBarChart({
 
         for (const svgElement of svgElements) {
             const svgStyleElement = svgElement.querySelector('style');
-            const svgImageElement = svgElement.querySelector('image');
 
             if (svgStyleElement !== null) {
                 svgStyleElement.parentNode?.removeChild(svgStyleElement);
-            }
-
-            if (svgImageElement !== null) {
-                svgImageElement.parentNode?.removeChild(svgImageElement);
             }
         }
 

--- a/webview-ui/src/diagnostics_panel/controls/MinecraftStatisticStackedLineChart.tsx
+++ b/webview-ui/src/diagnostics_panel/controls/MinecraftStatisticStackedLineChart.tsx
@@ -67,6 +67,7 @@ export default function MinecraftStatisticStackedLineChart({
         const latestTime = data.length !== 0 ? data[data.length - 1].time : 0;
 
         const plot = Plot.plot({
+            className: 'minecraft-statistic-stacked-line-chart',
             color: {
                 legend: true,
                 tickFormat: d => {

--- a/webview-ui/src/diagnostics_panel/controls/MinecraftStatisticStackedLineChart.tsx
+++ b/webview-ui/src/diagnostics_panel/controls/MinecraftStatisticStackedLineChart.tsx
@@ -105,6 +105,8 @@ export default function MinecraftStatisticStackedLineChart({
             ],
         });
 
+        console.log(plot);
+
         if (containerRef.current !== null) {
             containerRef.current.append(plot);
         }

--- a/webview-ui/src/diagnostics_panel/controls/MinecraftStatisticStackedLineChart.tsx
+++ b/webview-ui/src/diagnostics_panel/controls/MinecraftStatisticStackedLineChart.tsx
@@ -70,6 +70,8 @@ export default function MinecraftStatisticStackedLineChart({
             className: 'minecraft-statistic-stacked-line-chart',
             color: {
                 legend: true,
+                type: 'ordinal',
+                scheme: 'Observable10',
                 tickFormat: d => {
                     const label = catageoryLabels !== undefined ? catageoryLabels[d] : undefined;
                     if (label !== undefined) {

--- a/webview-ui/src/diagnostics_panel/controls/MinecraftStatisticStackedLineChart.tsx
+++ b/webview-ui/src/diagnostics_panel/controls/MinecraftStatisticStackedLineChart.tsx
@@ -106,6 +106,27 @@ export default function MinecraftStatisticStackedLineChart({
             ],
         });
 
+        // Remove all style elements and attributes
+        const styleElement = plot.querySelector('style');
+        const svgElements = plot.querySelectorAll('svg');
+        const styleAttribute = plot.getAttributeNode('style');
+
+        if (styleElement !== null) {
+            styleElement.parentNode?.removeChild(styleElement);
+        }
+
+        for (const svgElement of svgElements) {
+            const svgStyleElement = svgElement.querySelector('style');
+
+            if (svgStyleElement !== null) {
+                svgStyleElement.parentNode?.removeChild(svgStyleElement);
+            }
+        }
+
+        if (styleAttribute !== null) {
+            plot.removeAttributeNode(styleAttribute);
+        }
+
         if (containerRef.current !== null) {
             containerRef.current.append(plot);
         }

--- a/webview-ui/src/diagnostics_panel/controls/MinecraftStatisticStackedLineChart.tsx
+++ b/webview-ui/src/diagnostics_panel/controls/MinecraftStatisticStackedLineChart.tsx
@@ -105,8 +105,6 @@ export default function MinecraftStatisticStackedLineChart({
             ],
         });
 
-        console.log(plot);
-
         if (containerRef.current !== null) {
             containerRef.current.append(plot);
         }


### PR DESCRIPTION
> Discussion: https://github.com/Mojang/minecraft-debugger/pull/71#issuecomment-2182061131

Adding these CSS properties from Observable Plot's in-line styling, which are extracted from HTML style element generated from `const plot: HTMLElement = Plot.plot()` in format of `<class name>-<legend type>`, i.e. `-ramp` `-swatches`, to a CSS file allows margin between each category meanwhile maintaining full CSP protection.

The HTML element returns from the plot variable with `className` property defined:
```css
<figure class>...
<style>
:where(.minecraft-statistic-stacked-line-chart-swatches) {...}
:where(.minecraft-statistic-stacked-line-chart-swatch > svg) {...}
:where(.minecraft-statistic-stacked-line-chart-swatches-wrap) {...}
:where(.minecraft-statistic-stacked-line-chart-swatches-wrap .minecraft-statistic-stacked-line-chart-swatch) {...}
...
</style>
...</figure>
```

To avoid any CSP violations, all the plots must have their styles saved in a CSS file (`App.css`) and removing all the inline styles from generated HTML elements for all types of plots.

Specifically these attributes and elements:

![image](https://github.com/Mojang/minecraft-debugger/assets/65847850/73027570-b4f6-461e-b6ee-6e1eb31bc2ab)

I also set the scale type in `color.type` to ordinal, otherwise Observable Plot would incorrectly 'guess' the type of chart and attempts to show the category bar and throws CSP errors.

![image](https://github.com/Mojang/minecraft-debugger/assets/65847850/f88c84a3-124c-48db-96da-1268d3cb8a57)

> Category bar shown with CSP disabled.

The `color.scheme` is set to 'Observable10' to maintain the color scheme like before.
