### PR TITLE
Fix Debug Console Filtering Issue

### DIFF
--- a/src/Session.ts
+++ b/src/Session.ts
@@ -654,7 +654,7 @@ export class Session extends DebugSession {
             }
         }
 
-        this.sendEvent(new LogOutputEvent(message, logLevel));
+        this.sendEvent(new LogOutputEvent(message.trimEnd() + '\n', logLevel));
     }
     // Debugee (MC) responses to pending VSCode requests. Promises contained in a map keyed by
     // the sequence number of the request. Fascilitates the 'await sendDebugeeRequestAsync(...)' pattern.


### PR DESCRIPTION
Due to an idiosyncrasy with VSCode receiving debugee messages from `console.log`, all the output was being squashed into one large string which prevents the Debug Console from usefully filtering. This adds a small workaround which allows messages sent to the Debug Console to be properly appended as new lines allowing the filter to work for Minecraft scripts using `console.log`.