### PR TITLE
fix(sourcemaps): In-line source maps with charset would fail to be loaded

### DIFF
--- a/src/SourceMaps.ts
+++ b/src/SourceMaps.ts
@@ -94,7 +94,7 @@ class SourceMapCache {
 
                 let mapJson;
                 if (this._inlineSourceMap) {
-                    const inlineSourceMapRegex = /\/\/# sourceMappingURL=data:application\/json;base64,(.*)$/gm;
+                    const inlineSourceMapRegex = /\/\/# sourceMappingURL=data:application\/json;.*;base64,(.*)$/gm;
                     const match = inlineSourceMapRegex.exec(mapFile.toString());
                     const sourceRoot = path.join(
                         this._localRoot ?? '',


### PR DESCRIPTION
Made the regex for matching in-line source maps a little less strict.  This is an example of one that would fail to load:


`//# sourceMappingURL=data:application/json;charset=utf8;base64,eyJ2ZXJzaW9uIjozLCJzb3...`