### PR TITLE
chore(packaging): Updated version in package.json to `0.0.0-semantically-released`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "minecraft-debugger",
-    "version": "1.7.0",
+    "version": "0.0.0-semantically-released",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "minecraft-debugger",
-            "version": "1.7.0",
+            "version": "0.0.0-semantically-released",
             "license": "MIT",
             "dependencies": {
                 "@vscode/webview-ui-toolkit": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "minecraft-debugger",
     "displayName": "Minecraft Bedrock Edition Debugger",
     "description": "Debug your JavaScript code running in Minecraft Bedrock Edition.",
-    "version": "1.7.0",
+    "version": "0.0.0-semantically-released",
     "publisher": "mojang-studios",
     "author": {
         "name": "Mojang Studios"


### PR DESCRIPTION
Done to indicate that the version in `package.json` is not used.

Recommended here: https://semantic-release.gitbook.io/semantic-release/support/faq#why-is-the-package.jsons-version-not-updated-in-my-repository