### PR TITLE
fix(typescript): Original source absolute path resolution updates

### DIFF
--- a/src/Session.ts
+++ b/src/Session.ts
@@ -740,7 +740,7 @@ export class Session extends DebugSession {
             return false;
         }
         try {
-            let fileNames = fs.readdirSync(filePath);
+            let fileNames = fs.readdirSync(filePath, { encoding: null, recursive: true });
             for (let fn of fileNames) {
                 if (extensions.some(ext => fn.endsWith(ext))) {
                     return true;

--- a/src/SourceMaps.ts
+++ b/src/SourceMaps.ts
@@ -132,13 +132,13 @@ class SourceMapCache {
                     if (path.isAbsolute(originalSource)) {
                         // we have an absolute path already, so generate a relative path to the current dir
                         originalSourceAbsolutePath = originalSource;
-                        originalSourceRelative = path.relative(this._sourceMapRoot, originalSourceAbsolutePath);
+                        originalSourceRelative = path.relative(path.dirname(mapFullPath), originalSourceAbsolutePath);
                         preferAbsolute = true;
                     } else {
                         // generate relative path from map to ts file
                         originalSourceRelative = normalizePathForRemote(originalSource);
                         // map has relative path back to original source, resolve for absolute path
-                        originalSourceAbsolutePath = path.resolve(this._sourceMapRoot, originalSourceRelative);
+                        originalSourceAbsolutePath = path.resolve(path.dirname(mapFullPath), originalSourceRelative);
                     }
 
                     // collect all relevant path info, used for resolving original->generated and generated->original


### PR DESCRIPTION
If I'm getting this correctly, the absolute path to the original source file should be solved relatively not from the source map root directory, but rather from the source map file's parent directory. A slight nuance that breaks the mapping when using a nested directory structure for the generated source files.

The change required allowing a recursive check of the source map root directory when checking for `.map` files.