### PR TITLE
feat(diagnostics): Display category value on hover of stacked graph

### DIFF
--- a/webview-ui/src/diagnostics_panel/App.css
+++ b/webview-ui/src/diagnostics_panel/App.css
@@ -27,6 +27,10 @@ main {
   max-width: initial;
 }
 
+.minecraft-statistic-stacked-line-chart-figure tspan {
+  fill: black;
+}
+
 .minecraft-statistic-stacked-line-chart-swatches {
   font-family: system-ui, sans-serif;
   font-size: 10px;
@@ -89,6 +93,10 @@ main {
   display: inline-flex;
   align-items: center;
   margin-right: 1em;
+}
+
+.minecraft-statistic-stacked-bar-chart tspan {
+  fill: black;
 }
 
 /* .minecraft-statistic-stacked-bar-chart {

--- a/webview-ui/src/diagnostics_panel/controls/MinecraftStatisticStackedBarChart.tsx
+++ b/webview-ui/src/diagnostics_panel/controls/MinecraftStatisticStackedBarChart.tsx
@@ -78,7 +78,10 @@ export default function MinecraftStatisticStackedBarChart({
                     x: 'time',
                     y: 'value',
                     fill: 'category',
-                    title: 'category',
+                    title: d => `category: ${d.category}\nvalue: ${d.value}`,
+                    tip: {
+                        fontSize: 12,
+                    },
                 }),
                 Plot.ruleY([0]),
             ],

--- a/webview-ui/src/diagnostics_panel/controls/MinecraftStatisticStackedLineChart.tsx
+++ b/webview-ui/src/diagnostics_panel/controls/MinecraftStatisticStackedLineChart.tsx
@@ -102,7 +102,7 @@ export default function MinecraftStatisticStackedLineChart({
                     x: 'time',
                     y: 'value',
                     fill: 'category',
-                    title: d => `category: ${d.category}\nvalue: ${d.value.toFixed(3)}`,
+                    title: d => `category: ${d.category}\nvalue: ${parseFloat(d.value.toFixed(3))}`,
                     tip: {
                         fontSize: 12,
                     },

--- a/webview-ui/src/diagnostics_panel/controls/MinecraftStatisticStackedLineChart.tsx
+++ b/webview-ui/src/diagnostics_panel/controls/MinecraftStatisticStackedLineChart.tsx
@@ -102,7 +102,10 @@ export default function MinecraftStatisticStackedLineChart({
                     x: 'time',
                     y: 'value',
                     fill: 'category',
-                    title: 'category',
+                    title: d => `category: ${d.category}\nvalue: ${d.value.toFixed(3)}`,
+                    tip: {
+                        fontSize: 12,
+                    },
                 }),
                 Plot.ruleY([0]),
                 targetValue ? Plot.ruleY([targetValue]) : undefined,


### PR DESCRIPTION
Added a tip to stacked line and bar charts to display values of the category being hovered over.

Examples:
![image](https://github.com/user-attachments/assets/354d4073-ad39-46fe-b042-0abc047a36c8)
![image](https://github.com/user-attachments/assets/3fccfed3-2b93-4910-bc26-f302e8538011)
![image](https://github.com/user-attachments/assets/dcf94c42-56f4-4bd3-a598-93054d020826)
