### PR TITLE
feat(diagnostics) Add a extension setting to open the diagnostic view on connection

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,7 +159,16 @@
                     "PromptForPort": "extension.minecraft-js.getPort"
                 }
             }
-        ]
+        ],
+        "configuration": {
+            "properties": {
+                "minecraft-debugger.showDiagnosticViewOnConnect": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Open the diagnostics view on connection to Minecraft."
+                }
+            }
+        }
     },
     "scripts": {
         "install:all": "npm install && cd webview-ui && npm install",

--- a/src/Session.ts
+++ b/src/Session.ts
@@ -17,7 +17,7 @@ import { DebugProtocol } from '@vscode/debugprotocol';
 import { LogOutputEvent, LogLevel } from '@vscode/debugadapter/lib/logger';
 import { MessageStreamParser } from './MessageStreamParser';
 import { SourceMaps } from './SourceMaps';
-import { FileSystemWatcher, window, workspace } from 'vscode';
+import { FileSystemWatcher, window, workspace, commands } from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
 import { isUUID } from './Utils';
@@ -498,6 +498,11 @@ export class Session extends DebugSession {
         // When config is complete VSCode calls 'configurationDoneRequest' and the DA
         // sends a 'resume' message to the debugee, which had paused following the attach.
         this.sendEvent(new InitializedEvent());
+
+        // If the user has set the configuration to show the diagnostic view on connect in settings.json, show it now.
+        if (workspace.getConfiguration('minecraft-debugger').get('showDiagnosticViewOnConnect')) {
+            commands.executeCommand('minecraft-debugger.showMinecraftDiagnostics');
+        }
     }
 
     // stop listening for connections


### PR DESCRIPTION
### Summary
Adds an extension setting `minecraft-debugger.showDiagnosticViewOnConnect` which when true automatically opens the diagnostic view when a complete connection occurs.

If approved possibly worth a mention in the readme?

Resolves #145 