### PR TITLE
feat(diagnostics): auto select the first element in the client or plugin dropdowns when opening the diagnostics panel.

### DIFF
--- a/webview-ui/src/diagnostics_panel/App.tsx
+++ b/webview-ui/src/diagnostics_panel/App.tsx
@@ -40,8 +40,8 @@ function constructSubscribedSignalFilter() {
 
 function App() {
     // State
-    const [selectedPlugin, setSelectedPlugin] = useState<string>('no_plugin_selected');
-    const [selectedClient, setSelectedClient] = useState<string>('no_client_selected');
+    const [selectedPlugin, setSelectedPlugin] = useState<string>('');
+    const [selectedClient, setSelectedClient] = useState<string>('');
     const [currentTab, setCurrentTab] = useState<string>();
 
     // Load initial state from vscode
@@ -117,7 +117,6 @@ function App() {
                 <VSCodePanelView id="view-4" style={{ flexDirection: 'column' }}>
                     <StatGroupSelectionBox
                         labelName="Client"
-                        defaultDropdownId="no_client_selected"
                         statParentId="client_frame_timings"
                         onChange={handleClientSelection}
                     />
@@ -185,7 +184,6 @@ function App() {
                 <VSCodePanelView id="view-7">
                     <StatGroupSelectionBox
                         labelName="Script Plugin"
-                        defaultDropdownId="no_plugin_selected"
                         statParentId="handle_counts"
                         onChange={handlePluginSelection}
                     />
@@ -223,7 +221,6 @@ function App() {
                 <VSCodePanelView id="view-8">
                     <StatGroupSelectionBox
                         labelName="Script Plugin"
-                        defaultDropdownId="no_plugin_selected"
                         statParentId="fine_grained_subscribers"
                         onChange={handlePluginSelection}
                     />

--- a/webview-ui/src/diagnostics_panel/controls/StatGroupSelectionBox.tsx
+++ b/webview-ui/src/diagnostics_panel/controls/StatGroupSelectionBox.tsx
@@ -53,12 +53,11 @@ export function StatGroupSelectionBox({ labelName, statParentId, onChange }: Sel
                                 return x.id === msg.data.id;
                             }) === -1
                         ) {
-                            const newState = [...(prevState ?? []), { id: msg.data.id, name: msg.data.name }];
-                            // auto select the first group we get
-                            if (!selectedGroupId && newState.length === 1) {
+                            // auto select the first group we get if none is selected
+                            if (!selectedGroupId) {
                                 setSelectedGroupId(msg.data.id);
-                                onChange(msg.data.id);
                             }
+                            const newState = [...(prevState ?? []), { id: msg.data.id, name: msg.data.name }];
                             return newState;
                         }
                         return prevState;

--- a/webview-ui/src/diagnostics_panel/controls/StatGroupSelectionBox.tsx
+++ b/webview-ui/src/diagnostics_panel/controls/StatGroupSelectionBox.tsx
@@ -14,12 +14,10 @@ interface StatGroupEntry {
     name: string;
 }
 
-type SelectedGroupId = string | undefined;
-
 export function StatGroupSelectionBox({ labelName, statParentId, onChange }: SelectionBoxProps) {
     // the groups directly under the 'statParentId'
     const [groups, setGroup] = useState<StatGroupEntry[]>([]);
-    const [selectedGroupId, setSelectedGroupId] = useState<SelectedGroupId>(undefined);
+    const [selectedGroupId, setSelectedGroupId] = useState<string | undefined>(undefined);
 
     const _onChange = useCallback(
         (e: Event | React.FormEvent<HTMLElement>): void => {
@@ -46,17 +44,13 @@ export function StatGroupSelectionBox({ labelName, statParentId, onChange }: Sel
                     }
                     // Add it to the list
                     setGroup(prevState => {
-                        // See if the group is not in the list
-                        if (
-                            prevState === undefined ||
-                            prevState?.findIndex(x => {
-                                return x.id === msg.data.id;
-                            }) === -1
-                        ) {
-                            // auto select the first group we get if none is selected
+                        const isNewGroup = !prevState || prevState.findIndex(x => x.id === msg.data.id) === -1;
+                        if (isNewGroup) {
+                            // auto select the first group we get if nothing selected
                             if (!selectedGroupId) {
                                 setSelectedGroupId(msg.data.id);
                             }
+                            // add new group to end of list
                             const newState = [...(prevState ?? []), { id: msg.data.id, name: msg.data.name }];
                             return newState;
                         }

--- a/webview-ui/src/diagnostics_panel/controls/StatGroupSelectionBox.tsx
+++ b/webview-ui/src/diagnostics_panel/controls/StatGroupSelectionBox.tsx
@@ -5,7 +5,6 @@ import { VSCodeDropdown, VSCodeOption } from '@vscode/webview-ui-toolkit/react';
 
 type SelectionBoxProps = {
     labelName: string;
-    defaultDropdownId: string;
     statParentId: string;
     onChange: (selectedGroupId: string) => void;
 };
@@ -15,9 +14,12 @@ interface StatGroupEntry {
     name: string;
 }
 
-export function StatGroupSelectionBox({ labelName, defaultDropdownId, statParentId, onChange }: SelectionBoxProps) {
+type SelectedGroupId = string | undefined;
+
+export function StatGroupSelectionBox({ labelName, statParentId, onChange }: SelectionBoxProps) {
     // the groups directly under the 'statParentId'
-    const [groups, setGroup] = useState<StatGroupEntry[]>([{ id: defaultDropdownId, name: 'n/a' }]);
+    const [groups, setGroup] = useState<StatGroupEntry[]>([]);
+    const [selectedGroupId, setSelectedGroupId] = useState<SelectedGroupId>(undefined);
 
     const _onChange = useCallback(
         (e: Event | React.FormEvent<HTMLElement>): void => {
@@ -26,6 +28,10 @@ export function StatGroupSelectionBox({ labelName, defaultDropdownId, statParent
         },
         [groups]
     );
+
+    useEffect(() => {
+        onChange(selectedGroupId || "");
+    }, [selectedGroupId]);
 
     //draws chart
     useEffect(() => {
@@ -47,7 +53,13 @@ export function StatGroupSelectionBox({ labelName, defaultDropdownId, statParent
                                 return x.id === msg.data.id;
                             }) === -1
                         ) {
-                            return [...(prevState ?? []), { id: msg.data.id, name: msg.data.name }];
+                            const newState = [...(prevState ?? []), { id: msg.data.id, name: msg.data.name }];
+                            // auto select the first group we get
+                            if (!selectedGroupId && newState.length === 1) {
+                                setSelectedGroupId(msg.data.id);
+                                onChange(msg.data.id);
+                            }
+                            return newState;
                         }
                         return prevState;
                     });
@@ -66,10 +78,12 @@ export function StatGroupSelectionBox({ labelName, defaultDropdownId, statParent
     return (
         <div className="dropdown-container">
             <label htmlFor="my-dropdown">{labelName}</label>
-            <VSCodeDropdown id="my-dropdown" onChange={_onChange}>
-                {(groups ?? []).map(option => {
-                    return <VSCodeOption key={option.id}>{option.name}</VSCodeOption>;
-                })}
+            <VSCodeDropdown id="my-dropdown" onChange={_onChange} disabled={groups.length === 0}>
+                {(groups ?? []).map(option => (
+                    <VSCodeOption key={option.id}>
+                        {option.name}
+                    </VSCodeOption>
+                ))}
             </VSCodeDropdown>
         </div>
     );


### PR DESCRIPTION
Dropdown disabled until at least one option has been determined.
Dropdown auto-selects the first item in the list.

fixes #144 