### PR TITLE
feat(diagnostics):  Add a reload command and support command keybinds

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,16 @@
             {
                 "command": "minecraft-debugger.showMinecraftDiagnostics",
                 "title": "Minecraft Diagnostics: Show"
+            },
+            {
+                "command": "minecraft-debugger.minecraftReload",
+                "title": "Minecraft Diagnostics: Reload MC "
+            }
+        ],
+        "keybindings":[
+            {
+                "command": "minecraft-debugger.minecraftReload",
+                "key": "ctrl+shift+r"
             }
         ],
         "breakpoints": [

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
             },
             {
                 "command": "minecraft-debugger.minecraftReload",
-                "title": "Minecraft Diagnostics: Reload MC "
+                "title": "Minecraft Reload"
             }
         ],
         "keybindings":[

--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
         "keybindings":[
             {
                 "command": "minecraft-debugger.minecraftReload",
-                "key": "ctrl+shift+r"
+                "key": "ctrl+shift+r",
+                "when": "editorLangId == typescript || editorLangId == javascript"
             }
         ],
         "breakpoints": [

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
             {
                 "command": "minecraft-debugger.minecraftReload",
                 "key": "ctrl+shift+r",
-                "when": "editorLangId == typescript || editorLangId == javascript"
+                "when": "editorLangId == typescript || editorLangId == javascript && inDebugMode"
             }
         ],
         "breakpoints": [

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
             {
                 "command": "minecraft-debugger.minecraftReload",
                 "key": "ctrl+shift+r",
-                "when": "editorLangId == typescript || editorLangId == javascript && inDebugMode"
+                "when": "inDebugMode && editorLangId == typescript || inDebugMode && editorLangId == javascript"
             }
         ],
         "breakpoints": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,3 @@
-
 // Copyright (C) Microsoft Corporation.  All rights reserved.
 
 import * as vscode from 'vscode';
@@ -49,8 +48,15 @@ export function activate(context: vscode.ExtensionContext) {
         }
     );
 
+    const minecraftReloadCommand = vscode.commands.registerCommand('minecraft-debugger.minecraftReload', () => {
+        if (!vscode.debug.activeDebugSession) {
+            vscode.window.showErrorMessage('Error running command reload: No active Minecraft Debugger session.');
+        }
+        eventEmitter.emit('run-minecraft-command', 'reload');
+    });
+
     // Add command to the extension context
-    context.subscriptions.push(showDiagnosticsCommand);
+    context.subscriptions.push(showDiagnosticsCommand, minecraftReloadCommand);
 }
 
 // called when extension is deactivated

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,3 +1,4 @@
+
 // Copyright (C) Microsoft Corporation.  All rights reserved.
 
 import * as vscode from 'vscode';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -55,8 +55,28 @@ export function activate(context: vscode.ExtensionContext) {
         eventEmitter.emit('run-minecraft-command', 'reload');
     });
 
+    // Create a command to allow keyboard shortcuts to run Minecraft commands
+    const runMinecraftCommand = vscode.commands.registerCommand(
+        'minecraft-debugger.runMinecraftCommand',
+        (...args: any[]) => {
+            if (args.length === 0) {
+                vscode.window.showErrorMessage('No command provided.');
+                return;
+            }
+            const command = args[0]; // Use only the first argument
+            if (typeof command !== 'string') {
+                vscode.window.showErrorMessage('Command must be a string.');
+                return;
+            }
+            if (!vscode.debug.activeDebugSession) {
+                vscode.window.showErrorMessage('Error running command: No active Minecraft Debugger session.');
+            }
+            eventEmitter.emit('run-minecraft-command', command);
+        }
+    );
+
     // Add command to the extension context
-    context.subscriptions.push(showDiagnosticsCommand, minecraftReloadCommand);
+    context.subscriptions.push(showDiagnosticsCommand, minecraftReloadCommand, runMinecraftCommand);
 }
 
 // called when extension is deactivated

--- a/src/panels/HomeViewProvider.ts
+++ b/src/panels/HomeViewProvider.ts
@@ -62,7 +62,7 @@ export class HomeViewProvider implements vscode.WebviewViewProvider {
                 }
                 case 'run-minecraft-command': {
                     if (!message.command || message.command.trim() === '') {
-                        vscode.window.showErrorMessage('Minecraft Command Shotcut can not be empty.');
+                        vscode.window.showErrorMessage('Minecraft Command Shortcut can not be empty.');
                         return;
                     }
                     this._eventEmitter.emit('run-minecraft-command', message.command);

--- a/src/panels/HomeViewProvider.ts
+++ b/src/panels/HomeViewProvider.ts
@@ -61,6 +61,10 @@ export class HomeViewProvider implements vscode.WebviewViewProvider {
                     break;
                 }
                 case 'run-minecraft-command': {
+                    if (!message.command || message.command.trim() === '') {
+                        vscode.window.showErrorMessage('Minecraft Command Shotcut can not be empty.');
+                        return;
+                    }
                     this._eventEmitter.emit('run-minecraft-command', message.command);
                     break;
                 }


### PR DESCRIPTION
## Summary
- Adds a vscode command to reload in the command pallete `>Minecraft Diagnostics: Reload MC`
  - Added a keyboard shortcut for this `ctrl+shift+r` this can be edited by the user in keyboard shortcuts
- Added a vscode command which allows users to add custom keyboard shortcuts to run commands from `keybindings.json`
  - Example `{ "key": "ctrl+shift+t", "command": "minecraft-debugger.runMinecraftCommand", "args": "say hello" },`
 - Added an error message if you have an active debug session but try and run an empty command from within the home view

## To test:
- Launch a debug session of the extension
**Reload**
- Try and run the reload command without a session active an observe the warning message
- Start a debugging session
- Run the reload command from the command pallete, confirm it reloads in game
- Run the reload command from hot keys `ctrl+shift+r`, confirm it reloads in game
**Command Keybinds**
- Open the `keybindings.json` (stored in Roaming/Code/User/keybindings.json) or command pallete `>Preferences: Open Keyboard Shortcuts (JSON)`
- Add a keybinding such as:
  - ```[{ "key": "ctrl+shift+t", "command": "minecraft-debugger.runMinecraftCommand", "args": "say hello" }]```
- Save and use the keybind
- Confirm Scripting says hello
