### PR TITLE
feat(debugger): Update filewatch to look for .map and .js and send /reload to MC

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,15 @@ Now, hit "Start Debugging" inside of Visual Studio Code.
 
 As with when you debug against Minecraft clients, you can set breakpoints in your code by clicking on the left-hand side of the editor, on specific lines of code.
 
+#### Minecraft Debugger Home Panel
+The Activity Bar icon ![image](/icons/creeper_icon.png) will open the Minecraft Debugger home panel. Here you will find shortcuts for common actions, like opening Settings and showing the Diagnostics panel.
+
+##### Minecraft Command Shortcuts
+Add shortcuts for your favorite Minecraft commands.
+
+##### Script Profiler
+After setting a local path for saving captures, use `Start Profiler` and `Stop Profiler` to create profile captures of your actively running add-on.
+
 #### Diagnostics Window
 When attatched to a game server running Minecraft 1.21.10 or above, the debugger can display high level statistics to help diagnost performance issues.
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ The Activity Bar icon ![image](/icons/creeper_icon.png) will open the Minecraft 
 Add shortcuts for your favorite Minecraft commands.
 
 ##### Script Profiler
-After setting a local path for saving captures, use `Start Profiler` and `Stop Profiler` to create profile captures of your actively running add-on.
+After setting a local path for saving captures, use `Start Profiler` and `Stop Profiler` to create performance captures of your actively running add-on.
 
 #### Diagnostics Window
 When attatched to a game server running Minecraft 1.21.10 or above, the debugger can display high level statistics to help diagnost performance issues.

--- a/package.json
+++ b/package.json
@@ -184,8 +184,8 @@
                 },
                 "minecraft-debugger.reloadOnSourceChanges.delay": {
                     "type": "number",
-                    "default": 500,
-                    "description": "Delay in milliseconds before reloading Minecraft."
+                    "default": 100,
+                    "description": "Delay in milliseconds between detecting source changes and reloading Minecraft."
                 },
                 "minecraft-debugger.reloadOnSourceChanges.globPattern": {
                     "type": "string",

--- a/package.json
+++ b/package.json
@@ -177,6 +177,21 @@
         ],
         "configuration": {
             "properties": {
+                "minecraft-debugger.reloadOnSourceChanges.enabled": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Reload Minecraft on source changes. Watch localRoot or sourceMapRoot."
+                },
+                "minecraft-debugger.reloadOnSourceChanges.delay": {
+                    "type": "number",
+                    "default": 500,
+                    "description": "Delay in milliseconds before reloading Minecraft."
+                },
+                "minecraft-debugger.reloadOnSourceChanges.globPattern": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Override the default locations and monitor all workspace files with the specified glob pattern."
+                },
                 "minecraft-debugger.showDiagnosticViewOnConnect": {
                     "type": "boolean",
                     "default": false,

--- a/package.json
+++ b/package.json
@@ -190,7 +190,7 @@
                 "minecraft-debugger.reloadOnSourceChanges.globPattern": {
                     "type": "string",
                     "default": "",
-                    "description": "Override the default locations and monitor all workspace files with the specified glob pattern."
+                    "description": "Override the default locations and monitor any workspace files that match the glob pattern."
                 },
                 "minecraft-debugger.showDiagnosticViewOnConnect": {
                     "type": "boolean",

--- a/src/Session.ts
+++ b/src/Session.ts
@@ -1028,7 +1028,7 @@ export class Session extends DebugSession {
             return;
         }
 
-        const reloadOnSourceChangesDelay = Math.max(config.get<number>('reloadOnSourceChanges.delay') || 0, 0);
+        const reloadOnSourceChangesDelay = Math.max(config.get<number>('reloadOnSourceChanges.delay') ?? 0, 0);
         const reloadOnSourceChangesGlobPattern = config.get<string>('reloadOnSourceChanges.globPattern');
         
         // Either monitor the build output (TS->JS) by looking at .map and .js files in sourceMapRoot,

--- a/src/Session.ts
+++ b/src/Session.ts
@@ -1022,14 +1022,14 @@ export class Session extends DebugSession {
             this._sourceFileWatcher = undefined;
         }
 
-        const minReloadDelay = 500;
         const config = workspace.getConfiguration('minecraft-debugger');
         const reloadOnSourceChangesEnabled = config.get<boolean>('reloadOnSourceChanges.enabled');
-        const reloadOnSourceChangesDelay = Math.max(config.get<number>('reloadOnSourceChanges.delay') || minReloadDelay, minReloadDelay);
-        const reloadOnSourceChangesGlobPattern = config.get<string>('reloadOnSourceChanges.globPattern');
         if (!reloadOnSourceChangesEnabled) {
             return;
         }
+
+        const reloadOnSourceChangesDelay = config.get<number>('reloadOnSourceChanges.delay') || 0;
+        const reloadOnSourceChangesGlobPattern = config.get<string>('reloadOnSourceChanges.globPattern');
         
         // Either monitor the build output (TS->JS) by looking at .map and .js files in sourceMapRoot,
         // or monitor .js files directly if not using TS or source maps by looking at localRoot,

--- a/src/Session.ts
+++ b/src/Session.ts
@@ -20,6 +20,7 @@ import {
     InputBoxOptions,
     QuickPickItem,
     QuickPickOptions,
+    RelativePattern,
     Uri,
     workspace,
     window,
@@ -128,7 +129,7 @@ export class Session extends DebugSession {
     private _threads = new Set<number>();
     private _requests = new Map<number, PendingResponse>();
     private _sourceMaps: SourceMaps = new SourceMaps('');
-    private _fileWatcher?: FileSystemWatcher;
+    private _sourceFileWatcher?: FileSystemWatcher;
     private _activeThreadId: number = 0; // the one being debugged
     private _localRoot: string = '';
     private _sourceMapRoot?: string;
@@ -167,6 +168,11 @@ export class Session extends DebugSession {
         this._eventEmitter.removeAllListeners('start-profiler');
         this._eventEmitter.removeAllListeners('stop-profiler');
         this._eventEmitter.removeAllListeners('request-debugger-status');
+
+        if (this._sourceFileWatcher) {
+            this._sourceFileWatcher.dispose();
+            this._sourceFileWatcher = undefined;
+        }
     }
 
     // ------------------------------------------------------------------------
@@ -661,7 +667,7 @@ export class Session extends DebugSession {
         );
 
         // watch for source map changes
-        this.createSourceMapFileWatcher(this._sourceMapRoot);
+        this.createSourceMapFileWatcher(this._localRoot, this._sourceMapRoot);
 
         // Now that a connection is established, and capabilities have been delivered, send this event to
         // tell VSCode to ask Minecraft/debugee for config data (breakpoints etc).
@@ -689,11 +695,6 @@ export class Session extends DebugSession {
             this._connectionSocket.destroy();
         }
         this._connectionSocket = undefined;
-
-        if (this._fileWatcher) {
-            this._fileWatcher.dispose();
-            this._fileWatcher = undefined;
-        }
     }
 
     // close and terminate session (could be from debugee request)
@@ -1015,22 +1016,59 @@ export class Session extends DebugSession {
         }
     }
 
-    private createSourceMapFileWatcher(sourceMapRoot?: string) {
-        if (this._fileWatcher) {
-            this._fileWatcher.dispose();
-            this._fileWatcher = undefined;
+    private createSourceMapFileWatcher(localRoot: string, sourceMapRoot?: string) {
+        if (this._sourceFileWatcher) {
+            this._sourceFileWatcher.dispose();
+            this._sourceFileWatcher = undefined;
         }
-        if (sourceMapRoot) {
-            this._fileWatcher = workspace.createFileSystemWatcher('**/*.{map}', false, false, false);
-            this._fileWatcher.onDidChange(uri => {
-                this._sourceMaps.reset();
-            });
-            this._fileWatcher.onDidCreate(uri => {
-                this._sourceMaps.reset();
-            });
-            this._fileWatcher.onDidDelete(uri => {
-                this._sourceMaps.reset();
-            });
+
+        const minReloadDelay = 500;
+        const config = workspace.getConfiguration('minecraft-debugger');
+        const reloadOnSourceChangesEnabled = config.get<boolean>('reloadOnSourceChanges.enabled');
+        const reloadOnSourceChangesDelay = Math.max(config.get<number>('reloadOnSourceChanges.delay') || minReloadDelay, minReloadDelay);
+        const reloadOnSourceChangesGlobPattern = config.get<string>('reloadOnSourceChanges.globPattern');
+        if (!reloadOnSourceChangesEnabled) {
+            return;
+        }
+        
+        // Either monitor the build output (TS->JS) by looking at .map and .js files in sourceMapRoot,
+        // or monitor .js files directly if not using TS or source maps by looking at localRoot,
+        // or monitor a specific glob pattern for all files within the workspace.
+        let globPattern = undefined;
+        if (reloadOnSourceChangesGlobPattern) {
+            globPattern = new RelativePattern(workspace.workspaceFolders?.[0].uri.fsPath || '', reloadOnSourceChangesGlobPattern);
+        }
+        else if (sourceMapRoot) {
+            globPattern = new RelativePattern(sourceMapRoot, '**/*.{map,js}');
+        }
+        else if (localRoot) {
+            globPattern = new RelativePattern(localRoot, '**/*.js');
+        }
+
+        if (globPattern) {
+            this._sourceFileWatcher = workspace.createFileSystemWatcher(globPattern, false, false, false);
+        }
+
+        const doReload = (): void => {
+            this._sourceMaps.clearCache();
+            this.onRunMinecraftCommand('say §aPerforming Auto-Reload');
+            this.onRunMinecraftCommand('reload');
+        };
+
+        const debounce = (func: () => void, wait: number): (() => void) => {
+            let timeout: NodeJS.Timeout;
+            return () => {
+                clearTimeout(timeout);
+                timeout = setTimeout(func, wait);
+            };
+        };
+
+        const debouncedReload = debounce(doReload, reloadOnSourceChangesDelay);
+
+        if (this._sourceFileWatcher) {
+            this._sourceFileWatcher.onDidChange(debouncedReload);
+            this._sourceFileWatcher.onDidCreate(debouncedReload);
+            this._sourceFileWatcher.onDidDelete(debouncedReload);
         }
     }
 

--- a/src/Session.ts
+++ b/src/Session.ts
@@ -1038,7 +1038,7 @@ export class Session extends DebugSession {
         if (reloadOnSourceChangesGlobPattern) {
             const workspaceFolders = workspace.workspaceFolders;
             if (workspaceFolders && workspaceFolders.length > 0) {
-                globPattern = new RelativePattern(workspaceFolders[0].uri.fsPath || '', reloadOnSourceChangesGlobPattern);
+                globPattern = new RelativePattern(workspaceFolders[0].uri.fsPath ?? '', reloadOnSourceChangesGlobPattern);
             }
         }
         else if (sourceMapRoot) {

--- a/src/Session.ts
+++ b/src/Session.ts
@@ -1028,15 +1028,18 @@ export class Session extends DebugSession {
             return;
         }
 
-        const reloadOnSourceChangesDelay = config.get<number>('reloadOnSourceChanges.delay') || 0;
+        const reloadOnSourceChangesDelay = Math.max(config.get<number>('reloadOnSourceChanges.delay') || 0, 0);
         const reloadOnSourceChangesGlobPattern = config.get<string>('reloadOnSourceChanges.globPattern');
         
         // Either monitor the build output (TS->JS) by looking at .map and .js files in sourceMapRoot,
         // or monitor .js files directly if not using TS or source maps by looking at localRoot,
         // or monitor a specific glob pattern for all files within the workspace.
-        let globPattern = undefined;
+        let globPattern: RelativePattern | undefined = undefined;
         if (reloadOnSourceChangesGlobPattern) {
-            globPattern = new RelativePattern(workspace.workspaceFolders?.[0].uri.fsPath || '', reloadOnSourceChangesGlobPattern);
+            const workspaceFolders = workspace.workspaceFolders;
+            if (workspaceFolders && workspaceFolders.length > 0) {
+                globPattern = new RelativePattern(workspaceFolders[0].uri.fsPath || '', reloadOnSourceChangesGlobPattern);
+            }
         }
         else if (sourceMapRoot) {
             globPattern = new RelativePattern(sourceMapRoot, '**/*.{map,js}');

--- a/src/SourceMaps.ts
+++ b/src/SourceMaps.ts
@@ -221,7 +221,7 @@ export class SourceMaps {
                 : SourceMapConsumer.LEAST_UPPER_BOUND;
     }
 
-    public reset() {
+    public clearCache() {
         this._sourceMapCache.reset();
     }
 

--- a/src/panels/HomeViewProvider.ts
+++ b/src/panels/HomeViewProvider.ts
@@ -60,6 +60,10 @@ export class HomeViewProvider implements vscode.WebviewViewProvider {
                     vscode.commands.executeCommand('minecraft-debugger.showMinecraftDiagnostics');
                     break;
                 }
+                case 'show-settings': {
+                    vscode.commands.executeCommand('workbench.action.openSettings', '@ext:mojang-studios.minecraft-debugger');
+                    break;
+                }
                 case 'run-minecraft-command': {
                     if (!message.command || message.command.trim() === '') {
                         vscode.window.showErrorMessage('Minecraft Command Shortcut can not be empty.');

--- a/webview-ui/src/home_panel/App.tsx
+++ b/webview-ui/src/home_panel/App.tsx
@@ -1,10 +1,10 @@
 
 // Copyright (C) Microsoft Corporation.  All rights reserved.
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import CommandSection from './controls/CommandSection'
 import { CommandButton, CommandHandlers, getCommandHandlers } from './handlers/CommandHandlers';
-import DiagnosticSection from './controls/DiagnosticsSection';
+import GeneralSection from './controls/GeneralSection';
 import ProfilerSection from './controls/ProfilerSection';
 import { CaptureItem, ProfilerHandlers, getProfilerHandlers } from './handlers/ProfilerHandlers';
 import StatusSection from './controls/StatusSection';
@@ -20,6 +20,10 @@ const vscode: WebviewApi<unknown> = acquireVsCodeApi();
 
 const onShowDiagnosticsPanel = () => {
     vscode.postMessage({ type: 'show-diagnostics' });
+};
+
+const onShowSettings = () => {
+    vscode.postMessage({ type: 'show-settings' });
 };
 
 const onRunCommand = (command: string) => {
@@ -121,8 +125,9 @@ const App = () => {
             <StatusSection
                 debuggerConnected={debuggerConnected}
             />
-            <DiagnosticSection
+            <GeneralSection
                 onShowDiagnosticsPanel={onShowDiagnosticsPanel}
+                onShowSettings={onShowSettings}
             />
             <CommandSection
                 debuggerConnected={debuggerConnected}

--- a/webview-ui/src/home_panel/controls/GeneralSection.tsx
+++ b/webview-ui/src/home_panel/controls/GeneralSection.tsx
@@ -4,19 +4,23 @@
 import React from 'react';
 import { VSCodeButton } from '@vscode/webview-ui-toolkit/react';
 
-interface DiagnosticsSectionProps {
+interface GeneralSectionProps {
     onShowDiagnosticsPanel: () => void;
+    onShowSettings(): void;
 }
 
-const DiagnosticsSection: React.FC<DiagnosticsSectionProps> = ({ onShowDiagnosticsPanel }) => {
+const GeneralSection: React.FC<GeneralSectionProps> = ({ onShowDiagnosticsPanel, onShowSettings }) => {
     return (
         <div className="section">
-            <h3 className="title">Diagnostics</h3>
+            <h3 className="title">Actions</h3>
             <VSCodeButton className="standard-button" onClick={onShowDiagnosticsPanel}>
                 Show Diagnostics
+            </VSCodeButton>
+            <VSCodeButton className="standard-button" onClick={onShowSettings}>
+                Show Settings
             </VSCodeButton>
         </div>
     );
 };
 
-export default DiagnosticsSection;
+export default GeneralSection;


### PR DESCRIPTION
Similar to this PR [here](https://github.com/Mojang/minecraft-debugger/pull/246) but leans into VSCode settings for added flexibility. By using VSCode settings, users can choose to save settings globally or per workspace and it also gives us a place for documentation.

Thanks for the general glob pattern idea Dingsel.  Will this solve your use cases?

- file watching is off by default
- if enabled then both source map clear and /reload happen on source changes.
- if only `localRoot` is defined (no `sourceMapRoot`), the file watch pattern is *.js files from `localRoot`
- if `sourceMapRoot` is defined, the file watch pattern is for *.js and *.map from `sourceMapRoot`
- if `globPattern` is specified, the root is the workspace.
- delay for sending /reload to MC, minimum is 100ms to debounce the file changes.

Added a button to the home panel to open Settings UI directly to the debugger page.

Addresses issue #130 

