### PR TITLE
fix(breakpoints): Breakpoints could get overwritten when multiple TS files map to a single JS file.

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -359,7 +359,7 @@ export class Session extends DebugSession {
         for (let [sourcePath, sourceBreakpoints] of this._sourceBreakpointsMap) {
             let originalLocalAbsolutePath = path.normalize(sourcePath);
 
-            const originalBreakpoints = sourceBreakpoints || [];
+            const originalBreakpoints = sourceBreakpoints ?? [];
             let generatedRemoteLocalPath = undefined;
 
             try {
@@ -379,11 +379,11 @@ export class Session extends DebugSession {
                     for (let originalBreakpoint of originalBreakpoints) {
                         const generatedPosition = await this._sourceMaps.getGeneratedPositionFor({
                             source: originalLocalAbsolutePath,
-                            column: originalBreakpoint.column || 0,
+                            column: originalBreakpoint.column ?? 0,
                             line: originalBreakpoint.line,
                         });
                         generatedBreakpoints.push({
-                            line: generatedPosition.line || 0,
+                            line: generatedPosition.line ?? 0,
                             column: 0,
                         });
                     }

--- a/src/session.ts
+++ b/src/session.ts
@@ -411,6 +411,11 @@ export class Session extends DebugSession {
             this.sendDebuggeeMessage(envelope);
         }
 
+        // if all bps are removed from this file, ok to remove map entry after sending empty list to client
+        if (args.breakpoints === undefined || args.breakpoints.length === 0) {
+            this._sourceBreakpointsMap.delete(args.source.path);
+        }
+
         // notify vscode breakpoints have been set
         this.sendResponse(response);
     }


### PR DESCRIPTION
Maintain a map of source breakpoints per file.  VSCode's `setBreakpointRequest` is triggered per file whenever breakpoints are added or removed.  Since it does not provide all breakpoints for all files, we need to maintain our own record of every breakpoint for every file.  This way, we have all inputs available when constructing the complete list of BPs for a given generated file.  

