### PR TITLE
fix(source-maps): Improve error messages and logs when working with source maps. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,11 +111,6 @@
                                 "type": "string",
                                 "description": "The location of the generated source files (js). Not required if same as source maps."
                             },
-                            "inlineSourceMap": {
-                                "type": "boolean",
-                                "description": "Whether or not source maps are embedded in the generated source files. Overrides sourceMapRoot and generatedSourceRoot when true.",
-                                "default": false
-                            },
                             "host": {
                                 "type": "string",
                                 "description": "The host address the extension will connect to.",

--- a/src/session.ts
+++ b/src/session.ts
@@ -993,18 +993,6 @@ export class Session extends DebugSession {
         if (this._sourceMapRoot) {
             this.showNotification(`Source maps enabled.`, LogLevel.Log, true);
 
-            // look for .ts files, expected when source maps are enabled
-            const foundTS = this.doFilesWithExtExistAt(this._localRoot, ['.ts']);
-            if (foundTS) {
-                this.log(`Found .ts files at localRoot:[${this._localRoot}].`, LogLevel.Log);
-            } else {
-                this.showNotification(
-                    `Failed to find .ts files at localRoot:[${this._localRoot}].`,
-                    LogLevel.Warn,
-                    true
-                );
-            }
-
             // look for .map files, if not found enable inline source maps
             const foundMaps = this.doFilesWithExtExistAt(this._sourceMapRoot, ['.map']);
             if (foundMaps) {
@@ -1058,6 +1046,7 @@ export class Session extends DebugSession {
                 );
             }
 
+            // could help diagnose source maps if we error when .ts files are found but no sourceMapRoot is set
             const foundTS = this.doFilesWithExtExistAt(this._localRoot, ['.ts']);
             if (foundTS) {
                 this.showNotification(

--- a/src/session.ts
+++ b/src/session.ts
@@ -990,6 +990,16 @@ export class Session extends DebugSession {
     private checkSourceFilePaths() {
         this._inlineSourceMap = false;
 
+        if (this._localRoot) {
+            this.log(`localRoot:[${this._localRoot}].`, LogLevel.Log);
+        }
+        if (this._sourceMapRoot) {
+            this.log(`sourceMapRoot:[${this._sourceMapRoot}].`, LogLevel.Log);
+        }
+        if (this._generatedSourceRoot) {
+            this.log(`generatedSourceRoot:[${this._generatedSourceRoot}].`, LogLevel.Log);
+        }
+
         if (this._sourceMapRoot) {
             this.showNotification(`Source maps enabled.`, LogLevel.Log, true);
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -1015,7 +1015,7 @@ export class Session extends DebugSession {
                 );
             }
 
-            // if using inline source maps look for .js files, if not found and using inline source maps, warn user
+            // if using inline source maps look for .js files, if not found warn user
             if (this._inlineSourceMap) {
                 const foundJSAtSourceMapRoot = this.doFilesWithExtExistAt(this._sourceMapRoot, ['.js']);
                 if (foundJSAtSourceMapRoot) {

--- a/src/source-maps.ts
+++ b/src/source-maps.ts
@@ -174,7 +174,7 @@ class SourceMapCache {
 // Source map manager, responsible for loading source maps and translating
 // from original to generated positions and back again.
 export class SourceMaps {
-    private _localRoot: string;
+    private _localRoot: string; // used as fallback when source maps don't resolve/load
     private _sourceMapRoot?: string;
     private _sourceMapCache: SourceMapCache;
     private _sourceMapBias: number = SourceMapConsumer.LEAST_UPPER_BOUND;

--- a/src/source-maps.ts
+++ b/src/source-maps.ts
@@ -14,7 +14,7 @@ interface MapInfo {
     preferAbsolute: boolean; // if true, use absolute paths as that is what the source map contained
 }
 
-class InlineSourceMapError extends Error {}
+class SourceMapError extends Error {}
 
 class MapLookup {
     private _sourceToMapInfo = new Map<string, MapInfo>();
@@ -38,22 +38,15 @@ class SourceMapCache {
     private static readonly _jsFileExt: string = '.js';
     private _sourceMapRoot?: string;
     public _generatedSourceRoot?: string;
-    private _localRoot?: string;
     private _mapsLoaded: boolean = false;
     public _originalSourcePathToMapLookup = new MapLookup();
     public _generatedSourcePathToMapLookup = new MapLookup();
     private _inlineSourceMap: boolean = false;
 
-    public constructor(
-        sourceMapRoot?: string,
-        generatedSourceRoot?: string,
-        inlineSourceMap: boolean = false,
-        localRoot?: string
-    ) {
+    public constructor(sourceMapRoot?: string, generatedSourceRoot?: string, inlineSourceMap: boolean = false) {
         this._sourceMapRoot = sourceMapRoot ? path.normalize(sourceMapRoot) : undefined;
         this._generatedSourceRoot = generatedSourceRoot ? path.normalize(generatedSourceRoot) : undefined;
         this._inlineSourceMap = inlineSourceMap;
-        this._localRoot = localRoot ? path.normalize(localRoot) : undefined;
     }
 
     public reset() {
@@ -83,11 +76,19 @@ class SourceMapCache {
         }
 
         try {
-            const mapFileNames = this._findAllMapFilesInFolder(
-                this._sourceMapRoot,
-                undefined,
-                this._inlineSourceMap ? SourceMapCache._jsFileExt : SourceMapCache._mapFileExt
-            );
+            if (!fs.existsSync(this._sourceMapRoot)) {
+                throw new SourceMapError(
+                    `Failed to load source maps, invalid path sourceMapRoot:[${this._sourceMapRoot}]`
+                );
+            }
+
+            // find all .map files in the sourceMapRoot, or .js files if using inline source maps
+            const mapFileExt = this._inlineSourceMap ? SourceMapCache._jsFileExt : SourceMapCache._mapFileExt;
+            let mapFileNames = fs.readdirSync(this._sourceMapRoot, { encoding: null, recursive: true });
+            mapFileNames = mapFileNames.filter(file => {
+                return path.extname(file) === mapFileExt;
+            });
+
             for (let mapFileName of mapFileNames) {
                 const mapFullPath = path.resolve(this._sourceMapRoot, mapFileName);
                 let mapFile = fs.readFileSync(mapFullPath);
@@ -102,12 +103,8 @@ class SourceMapCache {
                         const decodedMap = Buffer.from(base64EncodedMap, 'base64').toString('utf8');
                         mapJson = JSON.parse(decodedMap);
                         mapJson.file = path.basename(mapFileName);
-                        const parts = mapFileName.split('\\scripts\\');
-                        if (parts.length > 1) {
-                            mapJson.sourceRoot = path.join(this._localRoot ?? '', path.dirname(parts[1]));
-                        }
                     } else {
-                        throw new InlineSourceMapError(`Failed to load inline source maps for file: ${mapFileName}`);
+                        throw new SourceMapError(`Failed to load inline source maps for file: ${mapFileName}`);
                     }
                 } else {
                     mapJson = JSON.parse(mapFile.toString());
@@ -161,7 +158,7 @@ class SourceMapCache {
                 }
             }
         } catch (e) {
-            if (e instanceof InlineSourceMapError) {
+            if (e instanceof SourceMapError) {
                 throw e;
             } else {
                 throw new Error(
@@ -171,24 +168,6 @@ class SourceMapCache {
         }
 
         this._mapsLoaded = true;
-    }
-
-    private _findAllMapFilesInFolder(
-        dirPath: string,
-        existingFiles?: Array<string>,
-        fileExtentsion: string = SourceMapCache._mapFileExt
-    ): Array<string> {
-        let fileNames = fs.readdirSync(dirPath);
-        let allFiles = existingFiles || [];
-        fileNames.forEach(file => {
-            const fullPath = path.join(dirPath, file);
-            if (fs.statSync(fullPath).isDirectory()) {
-                allFiles = this._findAllMapFilesInFolder(fullPath, allFiles, fileExtentsion);
-            } else if (path.extname(file) === fileExtentsion) {
-                allFiles.push(fullPath);
-            }
-        });
-        return allFiles;
     }
 }
 
@@ -210,7 +189,7 @@ export class SourceMaps {
     ) {
         this._localRoot = path.normalize(localRoot);
         this._sourceMapRoot = sourceMapRoot ? path.normalize(sourceMapRoot) : undefined;
-        this._sourceMapCache = new SourceMapCache(this._sourceMapRoot, generatedSourceRoot, inlineSourceMap, localRoot);
+        this._sourceMapCache = new SourceMapCache(this._sourceMapRoot, generatedSourceRoot, inlineSourceMap);
         this._sourceMapBias =
             sourceMapBias === 'greatestLowerBound'
                 ? SourceMapConsumer.GREATEST_LOWER_BOUND


### PR DESCRIPTION
Improve user messaging, including logs and notifications, when working with source maps. 
Output resolved `sourceMapRoot`, `localRoot`, and `generatedSourceRoot` to the debug console on connect. 
Show warning notifications when expected files are not found, like if `sourceMapRoot` is set but it can't find .map files or .js files, or if `sourceMapRoot` is not defined but .ts files are found in local root etc.

Remove `inlineSourceMaps` from package.json, infer inline or external from files found at `sourceMapRoot`. One less thing for the user to configure.

Remove special case for inline source maps when encountering /scripts/ in source folder.

TS Starter pack now works with inline source maps with a one line change in `just.config.ts`:
```
const bundleTaskOptions: BundleTaskParameters = {
  ...
  sourcemap: "inline", // <--- from true to 'inline'
  ...
};
```