### PR TITLE
fix(source-maps): Use alternate source map bias only if the default returns null and the alternate does not. Remove as user option to reduce config confusion.

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,10 +128,6 @@
                                 "type": "object",
                                 "description": "Module mapping for imports. Each key is an import name that will be mapped to the provided value. Used if modules are external (i.e. included as part of minecraft). Defaults to an empty object."
                             },
-                            "sourceMapBias": {
-                                "type": "string",
-                                "description": "The bias to use when mapping from generated code to source code. Can be either 'leastUpperBound' or 'greatestLowerBound'. Defaults to 'leastUpperBound'."
-                            },
                             "targetModuleUuid": {
                                 "type": "string",
                                 "description": "The script module uuid from the manifest.json of the Minecraft Add-On being debugged. Necessary if there are multiple Add-Ons active."

--- a/src/session.ts
+++ b/src/session.ts
@@ -74,7 +74,6 @@ interface IAttachRequestArguments extends DebugProtocol.AttachRequestArguments {
     port?: number;
     inputPort?: string;
     moduleMapping?: ModuleMapping;
-    sourceMapBias?: string;
     targetModuleUuid?: string;
     passcode?: string;
 }
@@ -135,7 +134,6 @@ export class Session extends DebugSession {
     private _generatedSourceRoot?: string;
     private _inlineSourceMap: boolean = false;
     private _moduleMapping?: ModuleMapping;
-    private _sourceMapBias?: string;
     private _targetModuleUuid?: string;
     private _clientProtocolVersion: number = ProtocolVersion._Unknown; // determined after connection
     private _minecraftCapabilities: MinecraftCapabilities = { supportsCommands: false, supportsProfiler: false };
@@ -301,7 +299,6 @@ export class Session extends DebugSession {
         this._sourceMapRoot = args.sourceMapRoot ? path.normalize(args.sourceMapRoot) : undefined;
         this._generatedSourceRoot = args.generatedSourceRoot ? path.normalize(args.generatedSourceRoot) : undefined;
         this._moduleMapping = args.moduleMapping;
-        this._sourceMapBias = args.sourceMapBias;
 
         // Listen or connect (default), depending on mode.
         // Attach makes more sense to use connect, but some MC platforms require using listen.
@@ -688,8 +685,7 @@ export class Session extends DebugSession {
             this._localRoot,
             this._sourceMapRoot,
             this._generatedSourceRoot,
-            this._inlineSourceMap,
-            this._sourceMapBias
+            this._inlineSourceMap
         );
 
         // watch for source map changes


### PR DESCRIPTION
In an effort to reduce config options (and confusion), this removes the sourceMapBias param from the launch config. The default source map bias is 'leastUpperBound', which works with our published ts config in TS Starter. This config is also used in the source-map unit tests.  If leastUpperBound fails, it will try greatestLowerBound but will not switch to that as the preferred bias unless it succeeds.
