### PR TITLE
fix(lint): adjust eslint settings and fix warnings

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,12 +8,44 @@
     "plugins": [
         "@typescript-eslint"
     ],
+    "extends": [
+        "eslint:recommended",
+        "plugin:@typescript-eslint/recommended"
+    ],
     "rules": {
-        "@typescript-eslint/naming-convention": "warn",
+        "@typescript-eslint/naming-convention": [
+            "warn",
+            { 
+                "selector": "default", 
+                "format": ["camelCase", "snake_case"], // protocol messages use snake_case
+                "leadingUnderscore": "allow"
+            },
+            {
+                "selector": "enumMember",
+                "format": ["PascalCase"],
+                "leadingUnderscore": "allow"
+            },
+            {
+                "selector": "variable",
+                "format": ["UPPER_CASE", "PascalCase"], // TODO: remove PascalCase uses
+                "modifiers": ["global", "const"]
+            },
+            {
+                "selector": "typeLike",
+                "format": ["PascalCase"]
+            }
+        ],
+        "@typescript-eslint/no-explicit-any": "off", // TODO: enable when messages are typed
+        "@typescript-eslint/no-non-null-assertion": "off",
         "@typescript-eslint/semi": ["warn", "always"],
         "curly": "warn",
         "eqeqeq": "warn",
-        "no-throw-literal": "warn"
+        // indent 4 spaces
+        "indent": ["warn", 4, { "SwitchCase": 1 }],
+        "no-throw-literal": "warn",
+        // turn off base rules as they can report incorrect errors
+        "no-unused-vars": "off",
+        "@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_" }]
     },
     "ignorePatterns": [
         "**/*.d.ts"

--- a/src/config-provider.ts
+++ b/src/config-provider.ts
@@ -1,4 +1,3 @@
-
 // Copyright (C) Microsoft Corporation.  All rights reserved.
 
 import * as vscode from 'vscode';
@@ -7,26 +6,27 @@ import * as vscode from 'vscode';
 // Custom fields specified in package.json.
 //
 export class ConfigProvider implements vscode.DebugConfigurationProvider {
+    resolveDebugConfiguration(
+        folder: vscode.WorkspaceFolder | undefined,
+        config: vscode.DebugConfiguration
+    ): vscode.ProviderResult<vscode.DebugConfiguration> {
+        // set some defaults to allow attach without a launch.json
+        if (!config.type) {
+            config.type = 'minecraft-js';
+        }
+        if (!config.request) {
+            config.request = 'attach';
+        }
+        if (!config.name) {
+            config.name = 'Attach to Minecraft';
+        }
+        if (!config.localRoot) {
+            config.localRoot = '${workspaceFolder}/scripts/';
+        }
+        if (!config.port) {
+            config.inputPort = '${command:PromptForPort}'; // prompt user for port
+        }
 
-	resolveDebugConfiguration(folder: vscode.WorkspaceFolder | undefined, config: vscode.DebugConfiguration, token?: vscode.CancellationToken): vscode.ProviderResult<vscode.DebugConfiguration> {
-
-		// set some defaults to allow attach without a launch.json
-		if (!config.type) {
-			config.type = 'minecraft-js';
-		}
-		if (!config.request) {
-			config.request = 'attach';
-		}
-		if (!config.name) {
-			config.name = 'Attach to Minecraft';
-		}
-		if (!config.localRoot) {
-			config.localRoot = "${workspaceFolder}/scripts/";
-		}
-		if (!config.port) {
-			config.inputPort = "${command:PromptForPort}"; // prompt user for port
-		}
-
-		return config;
-	}
+        return config;
+    }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,7 +11,7 @@ import { ReplayStatsProvider } from './stats/replay-stats-provider';
 
 // called when extension is activated
 //
-export function activate(context: vscode.ExtensionContext) {
+export function activate(context: vscode.ExtensionContext): void {
     const liveStatsProvider = new StatsProvider('Live', 'minecraftDiagnosticsLive');
     const eventEmitter: EventEmitter = new EventEmitter();
 
@@ -24,7 +24,7 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('minecraft-js', configProvider));
 
     // register a debug adapter descriptor factory for 'minecraft-js', this factory creates the DebugSession
-    let descriptorFactory = new ServerDebugAdapterFactory(homeViewProvider, liveStatsProvider, eventEmitter);
+    const descriptorFactory = new ServerDebugAdapterFactory(homeViewProvider, liveStatsProvider, eventEmitter);
     context.subscriptions.push(vscode.debug.registerDebugAdapterDescriptorFactory('minecraft-js', descriptorFactory));
     if ('dispose' in descriptorFactory) {
         context.subscriptions.push(descriptorFactory);
@@ -51,7 +51,7 @@ export function activate(context: vscode.ExtensionContext) {
     // Create a command to allow keyboard shortcuts to run Minecraft commands
     const runMinecraftCommand = vscode.commands.registerCommand(
         'minecraft-debugger.runMinecraftCommand',
-        (...args: any[]) => {
+        (...args: unknown[]) => {
             if (args.length === 0) {
                 vscode.window.showErrorMessage('No command provided.');
                 return;
@@ -79,8 +79,8 @@ export function activate(context: vscode.ExtensionContext) {
                 canSelectMany: false,
                 openLabel: 'Open',
                 filters: {
-                    'MC Stats Files': ['mcstats'],
-                    'All Files': ['*'],
+                    'MC Stats Files': ['mcstats'], // eslint-disable-line @typescript-eslint/naming-convention
+                    'All Files': ['*'], // eslint-disable-line @typescript-eslint/naming-convention
                 },
             });
             if (!fileUri || fileUri.length === 0) {
@@ -101,7 +101,3 @@ export function activate(context: vscode.ExtensionContext) {
         replayDiagnosticsCommand
     );
 }
-
-// called when extension is deactivated
-//
-export function deactivate() {}

--- a/src/message-stream-parser.ts
+++ b/src/message-stream-parser.ts
@@ -1,7 +1,8 @@
-
 // Copyright (C) Microsoft Corporation.  All rights reserved.
 
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const Parser = require('stream-parser');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const Transform = require('stream').Transform;
 
 // Data transform attached to socket.
@@ -9,22 +10,22 @@ const Transform = require('stream').Transform;
 // then raises them as events for consumption by the DA.
 //
 export class MessageStreamParser extends Transform {
-	constructor() {
-		super();
-		this._bytes(9, this.onLength);
-	}
+    constructor() {
+        super();
+        this._bytes(9, this.onLength);
+    }
 
-	private onLength(buffer: Buffer) {
-		let length = parseInt(buffer.toString(), 16);
-		this.emit('length', length);
-		this._bytes(length, this.onMessage);
-	}
+    private onLength(buffer: Buffer) {
+        const length = parseInt(buffer.toString(), 16);
+        this.emit('length', length);
+        this._bytes(length, this.onMessage);
+    }
 
-	private onMessage(buffer: Buffer) {
-		let json = JSON.parse(buffer.toString());
-		this.emit('message', json);
-		this._bytes(9, this.onLength);
-	}
+    private onMessage(buffer: Buffer) {
+        const json = JSON.parse(buffer.toString());
+        this.emit('message', json);
+        this._bytes(9, this.onLength);
+    }
 }
 
 Parser(MessageStreamParser.prototype);

--- a/src/panels/home-view-provider.ts
+++ b/src/panels/home-view-provider.ts
@@ -20,7 +20,7 @@ export class HomeViewProvider implements vscode.WebviewViewProvider {
         this._eventEmitter = eventEmitter;
     }
 
-    public setDebuggerStatus(isConnected: boolean, minecraftCapabilities: MinecraftCapabilities) {
+    public setDebuggerStatus(isConnected: boolean, minecraftCapabilities: MinecraftCapabilities): void {
         this._view?.webview.postMessage({
             type: 'debugger-status',
             isConnected: isConnected,
@@ -33,11 +33,7 @@ export class HomeViewProvider implements vscode.WebviewViewProvider {
         this._eventEmitter.emit('request-debugger-status');
     }
 
-    public resolveWebviewView(
-        webviewView: vscode.WebviewView,
-        _context: vscode.WebviewViewResolveContext,
-        _token: vscode.CancellationToken
-    ) {
+    public resolveWebviewView(webviewView: vscode.WebviewView): void {
         this._view = webviewView;
 
         this._view.webview.options = {

--- a/src/panels/minecraft-diagnostics.ts
+++ b/src/panels/minecraft-diagnostics.ts
@@ -99,7 +99,7 @@ export class MinecraftDiagnosticsPanel {
         this._statsTracker.addStatListener(this._statsCallback);
     }
 
-    public static render(extensionUri: Uri, statsTracker: StatsProvider) {
+    public static render(extensionUri: Uri, statsTracker: StatsProvider): void {
         const statsTrackerId = statsTracker.uniqueId;
         const existingPanel = MinecraftDiagnosticsPanel.activeDiagnosticsPanels.find(
             panel => panel._statsTracker.uniqueId === statsTrackerId
@@ -126,7 +126,7 @@ export class MinecraftDiagnosticsPanel {
         }
     }
 
-    public dispose() {
+    public dispose(): void {
         if (this._statsCallback !== undefined) {
             this._statsTracker.removeStatListener(this._statsCallback);
             this._statsCallback = undefined;

--- a/src/server-debug-adapter-factory.ts
+++ b/src/server-debug-adapter-factory.ts
@@ -21,10 +21,7 @@ export class ServerDebugAdapterFactory implements vscode.DebugAdapterDescriptorF
         this._eventEmitter = eventEmitter;
     }
 
-    createDebugAdapterDescriptor(
-        _session: vscode.DebugSession,
-        _executable: vscode.DebugAdapterExecutable | undefined
-    ): vscode.ProviderResult<vscode.DebugAdapterDescriptor> {
+    createDebugAdapterDescriptor(): vscode.ProviderResult<vscode.DebugAdapterDescriptor> {
         if (!this.server) {
             // start listening on a random port
             this.server = Net.createServer(socket => {
@@ -38,7 +35,7 @@ export class ServerDebugAdapterFactory implements vscode.DebugAdapterDescriptorF
         return new vscode.DebugAdapterServer((this.server.address() as Net.AddressInfo).port);
     }
 
-    dispose() {
+    dispose(): void {
         if (this.server) {
             this.server.close();
         }

--- a/src/stats/replay-stats-provider.test.ts
+++ b/src/stats/replay-stats-provider.test.ts
@@ -8,14 +8,14 @@ describe('ReplayStatsProvider', () => {
         const replayFilePath = path.resolve('./test/diagnostics-replay-compressed.mcstats');
         const replay = new ReplayStatsProvider(replayFilePath);
         let statCount = 0;
-        let statsCallback: StatsListener = {
+        const statsCallback: StatsListener = {
             onStatUpdated: (stat: StatData) => {
                 statCount++;
                 expect(stat).toBeDefined();
             },
         };
         replay.addStatListener(statsCallback);
-        let results = await replay.start();
+        const results = await replay.start();
         expect(results.statLinesRead).toBe(3);
         expect(results.statEventsSent).toBe(3);
         expect(statCount).toBeGreaterThan(0); // no idea how many are in there
@@ -25,14 +25,14 @@ describe('ReplayStatsProvider', () => {
         const replayFilePath = path.resolve('./test/diagnostics-replay-uncompressed.mcstats');
         const replay = new ReplayStatsProvider(replayFilePath);
         let statCount = 0;
-        let statsCallback: StatsListener = {
+        const statsCallback: StatsListener = {
             onStatUpdated: (stat: StatData) => {
                 statCount++;
                 expect(stat).toBeDefined();
             },
         };
         replay.addStatListener(statsCallback);
-        let results = await replay.start();
+        const results = await replay.start();
         expect(results.statLinesRead).toBe(3);
         expect(results.statEventsSent).toBe(3);
         expect(statCount).toBeGreaterThan(0);
@@ -42,14 +42,14 @@ describe('ReplayStatsProvider', () => {
         const replayFilePath = path.resolve('./test/diagnostics-replay-uncompressed-no-header.mcstats');
         const replay = new ReplayStatsProvider(replayFilePath);
         let statCount = 0;
-        let statsCallback: StatsListener = {
+        const statsCallback: StatsListener = {
             onStatUpdated: (stat: StatData) => {
                 statCount++;
                 expect(stat).toBeDefined();
             },
         };
         replay.addStatListener(statsCallback);
-        let results = await replay.start();
+        const results = await replay.start();
         expect(results.statLinesRead).toBe(3);
         expect(results.statEventsSent).toBe(3);
         expect(statCount).toBeGreaterThan(0);
@@ -59,19 +59,19 @@ describe('ReplayStatsProvider', () => {
         const replayFilePath = path.resolve('./test/diagnostics-replay-compressed.mcstats');
         const replay = new ReplayStatsProvider(replayFilePath);
         let statCount = 0;
-        let statsCallback: StatsListener = {
+        const statsCallback: StatsListener = {
             onStatUpdated: (stat: StatData) => {
                 statCount++;
                 expect(stat).toBeDefined();
             },
         };
         replay.addStatListener(statsCallback);
-        let results = await replay.start();
+        const results = await replay.start();
         expect(results.statLinesRead).toBe(3);
         expect(results.statEventsSent).toBe(3);
         expect(statCount).toBeGreaterThan(0);
         replay.stop();
-        let results2 = await replay.start();
+        const results2 = await replay.start();
         expect(results2.statLinesRead).toBe(3);
         expect(results2.statEventsSent).toBe(3);
     });
@@ -80,13 +80,13 @@ describe('ReplayStatsProvider', () => {
         const replayFilePath = './not-a-real-file.mcstats';
         const replay = new ReplayStatsProvider(replayFilePath);
         let notification = '';
-        let statsCallback: StatsListener = {
+        const statsCallback: StatsListener = {
             onNotification: (message: string) => {
                 notification = message;
             },
         };
         replay.addStatListener(statsCallback);
-        let results = await replay.start();
+        const results = await replay.start();
         expect(results.statLinesRead).toBe(0);
         expect(notification).toBe('Failed to read replay file.');
     });

--- a/src/stats/stats-provider.ts
+++ b/src/stats/stats-provider.ts
@@ -38,42 +38,42 @@ export class StatsProvider {
         this._statListeners = [];
     }
 
-    public setStats(stats: StatMessageModel) {
+    public setStats(stats: StatMessageModel): void {
         for (const stat of stats.stats) {
             this._fireStatUpdated(stat, stats.tick);
         }
     }
 
-    public start() {
+    public start(): void {
         throw new Error('Method not implemented.');
     }
-    public stop() {
+    public stop(): void {
         throw new Error('Method not implemented.');
     }
-    public pause() {
+    public pause(): void {
         throw new Error('Method not implemented.');
     }
-    public resume() {
+    public resume(): void {
         throw new Error('Method not implemented.');
     }
-    public faster() {
+    public faster(): void {
         throw new Error('Method not implemented.');
     }
-    public slower() {
+    public slower(): void {
         throw new Error('Method not implemented.');
     }
-    public setSpeed(speed: string) {
+    public setSpeed(_speed: string): void {
         throw new Error('Method not implemented.');
     }
     public manualControl(): boolean {
         return false;
     }
 
-    public addStatListener(listener: StatsListener) {
+    public addStatListener(listener: StatsListener): void {
         this._statListeners.push(listener);
     }
 
-    public removeStatListener(listener: StatsListener) {
+    public removeStatListener(listener: StatsListener): void {
         this._statListeners = this._statListeners.filter((l: StatsListener) => l !== listener);
     }
 
@@ -91,6 +91,7 @@ export class StatsProvider {
                 values: stat.values ?? [],
                 tick: tick,
             };
+
             listener.onStatUpdated?.(statData);
 
             if (stat.children) {

--- a/src/utilities/getNonce.ts
+++ b/src/utilities/getNonce.ts
@@ -6,11 +6,11 @@
  *
  * @returns A nonce
  */
-export function getNonce() {
-  let text = "";
-  const possible = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-  for (let i = 0; i < 32; i++) {
-    text += possible.charAt(Math.floor(Math.random() * possible.length));
-  }
-  return text;
+export function getNonce(): string {
+    let text = '';
+    const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    for (let i = 0; i < 32; i++) {
+        text += possible.charAt(Math.floor(Math.random() * possible.length));
+    }
+    return text;
 }

--- a/src/utilities/getUri.ts
+++ b/src/utilities/getUri.ts
@@ -1,4 +1,4 @@
-import { Uri, Webview } from "vscode";
+import { Uri, Webview } from 'vscode';
 
 /**
  * A helper function which will get the webview URI of a given file or resource.
@@ -11,6 +11,6 @@ import { Uri, Webview } from "vscode";
  * @param pathList An array of strings representing the path to a file/resource
  * @returns A URI pointing to the file/resource
  */
-export function getUri(webview: Webview, extensionUri: Uri, pathList: string[]) {
-  return webview.asWebviewUri(Uri.joinPath(extensionUri, ...pathList));
+export function getUri(webview: Webview, extensionUri: Uri, pathList: string[]): Uri {
+    return webview.asWebviewUri(Uri.joinPath(extensionUri, ...pathList));
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,41 +1,44 @@
-
 // Copyright (C) Microsoft Corporation.  All rights reserved.
 
 import * as os from 'os';
 import * as path from 'path';
 
-const enum CharCode {
-	Colon = 58,
-	A = 65,
-	Z = 90,
-	a = 97,
-	z = 122
+enum CharCode {
+    Colon = 58,
+    UppercaseA = 65,
+    UppercaseZ = 90,
+    LowercaseA = 97,
+    LowercaseZ = 122,
 }
+/* eslint-enable @typescript-eslint/naming-convention */
 
 function isWindowsDriveLetter(char0: number): boolean {
-	return char0 >= CharCode.A && char0 <= CharCode.Z || char0 >= CharCode.a && char0 <= CharCode.z;
+    return (
+        (char0 >= CharCode.UppercaseA && char0 <= CharCode.UppercaseZ) ||
+        (char0 >= CharCode.LowercaseA && char0 <= CharCode.LowercaseZ)
+    );
 }
 
 function hasDriveLetter(path: string, isWindowsOS: boolean): boolean {
-	if (isWindowsOS) {
-		return isWindowsDriveLetter(path.charCodeAt(0)) && path.charCodeAt(1) === CharCode.Colon;
-	}
-	return false;
+    if (isWindowsOS) {
+        return isWindowsDriveLetter(path.charCodeAt(0)) && path.charCodeAt(1) === CharCode.Colon;
+    }
+    return false;
 }
 
 export function normalizePath(filePath: string): string {
-	if (hasDriveLetter(filePath, os.type() == 'Windows_NT')) {
-		return path.normalize(filePath.charAt(0).toUpperCase() + filePath.slice(1));
-	}
+    if (hasDriveLetter(filePath, os.type() === 'Windows_NT')) {
+        return path.normalize(filePath.charAt(0).toUpperCase() + filePath.slice(1));
+    }
     return path.normalize(filePath);
 }
 
-export function normalizePathForRemote(filePath: string) {
-	// remote debugger expects forward slashes on all platforms
-	return filePath.replace(/\\/g,"/");
+export function normalizePathForRemote(filePath: string): string {
+    // remote debugger expects forward slashes on all platforms
+    return filePath.replace(/\\/g, '/');
 }
 
-export function isUUID(uuid: string) {
-	const regex = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/i;
-	return regex.test(uuid);
+export function isUUID(uuid: string): boolean {
+    const regex = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/i;
+    return regex.test(uuid);
 }


### PR DESCRIPTION
Defaults are coming from eslint:recommended from this section here:
```
"extends": [
    "eslint:recommended",
    "plugin:@typescript-eslint/recommended"
],
```
With a few changes specific to the Google style guide and our codebase.

The config for naming conventions is mostly a copy of the default [here](https://typescript-eslint.io/rules/naming-convention#options)

But with a few adjustments to allow snake_case properties, PascalCase globals, and PascalCase enum members.

Eventually we will turn off explicit-any when our protocol messages are properly typed.