### PR TITLE
feat: Added Entity System profile timings to a new Client Entity System tab

### DIFF
--- a/webview-ui/src/diagnostics_panel/controls/MinecraftMultiColumnStatisticTable.tsx
+++ b/webview-ui/src/diagnostics_panel/controls/MinecraftMultiColumnStatisticTable.tsx
@@ -33,6 +33,14 @@ type MultiColumnTrackedStat = {
     time: number;
 };
 
+type MinecraftMultiColumnStatisticTableRowAction = {
+    label: string;
+    onClick: (row: MultiColumnTrackedStat) => void;
+    disabled?: (row: MultiColumnTrackedStat) => boolean;
+    headerLabel?: string;
+    width?: string;
+};
+
 type NonConsolidatedColumnResolver = (event: StatisticUpdatedMessage, valueLabels: string[]) => number | undefined;
 
 type MinecraftMultiColumnStatisticTableProps = {
@@ -48,6 +56,7 @@ type MinecraftMultiColumnStatisticTableProps = {
     prettifyNames?: boolean; // Whether to format packet names (camelCase -> Camel Case) or keep original format
     columnWidths?: string[]; // Optional array of column widths (first is key column, rest are value columns)
     actions?: { label: string; onClick: () => void }[]; // Optional actions with labels and commands to run on click
+    rowAction?: MinecraftMultiColumnStatisticTableRowAction; // Optional per-row action button
     nonConsolidatedColumnResolver?: NonConsolidatedColumnResolver; // Maps split events to target columns for non-consolidated streams
     valueFormatter?: (value: string | number, columnIndex: number) => string; // Optional custom display formatter for cell values
 };
@@ -134,6 +143,7 @@ export default function MinecraftMultiColumnStatisticTable({
     prettifyNames = true, // Default to prettifying names for backward compatibility
     columnWidths,
     actions,
+    rowAction,
     nonConsolidatedColumnResolver,
     valueFormatter,
 }: MinecraftMultiColumnStatisticTableProps): JSX.Element {
@@ -444,6 +454,15 @@ export default function MinecraftMultiColumnStatisticTable({
                             {label}
                         </VSCodeDataGridCell>
                     ))}
+                    {rowAction && (
+                        <VSCodeDataGridCell
+                            cellType="columnheader"
+                            gridColumn={`${valueLabels.length + 2}`}
+                            style={{ width: rowAction.width || '140px' }}
+                        >
+                            {rowAction.headerLabel || 'Action'}
+                        </VSCodeDataGridCell>
+                    )}
                 </VSCodeDataGridRow>
                 {data.map(dataPoint => (
                     <VSCodeDataGridRow key={dataPoint.category}>
@@ -466,6 +485,19 @@ export default function MinecraftMultiColumnStatisticTable({
                                       : value}
                             </VSCodeDataGridCell>
                         ))}
+                        {rowAction && (
+                            <VSCodeDataGridCell
+                                gridColumn={`${valueLabels.length + 2}`}
+                                style={{ width: rowAction.width || '140px' }}
+                            >
+                                <VSCodeButton
+                                    onClick={() => rowAction.onClick(dataPoint)}
+                                    disabled={rowAction.disabled?.(dataPoint) ?? false}
+                                >
+                                    {rowAction.label}
+                                </VSCodeButton>
+                            </VSCodeDataGridCell>
+                        )}
                     </VSCodeDataGridRow>
                 ))}
             </VSCodeDataGrid>

--- a/webview-ui/src/diagnostics_panel/controls/MinecraftMultiColumnStatisticTable.tsx
+++ b/webview-ui/src/diagnostics_panel/controls/MinecraftMultiColumnStatisticTable.tsx
@@ -49,6 +49,7 @@ type MinecraftMultiColumnStatisticTableProps = {
     columnWidths?: string[]; // Optional array of column widths (first is key column, rest are value columns)
     actions?: { label: string; onClick: () => void }[]; // Optional actions with labels and commands to run on click
     nonConsolidatedColumnResolver?: NonConsolidatedColumnResolver; // Maps split events to target columns for non-consolidated streams
+    valueFormatter?: (value: string | number, columnIndex: number) => string; // Optional custom display formatter for cell values
 };
 
 const sortOrderOptions = [
@@ -134,6 +135,7 @@ export default function MinecraftMultiColumnStatisticTable({
     columnWidths,
     actions,
     nonConsolidatedColumnResolver,
+    valueFormatter,
 }: MinecraftMultiColumnStatisticTableProps): JSX.Element {
     // Memoize sort column options to prevent unnecessary recreations
     const sortColumnOptions = useMemo(
@@ -457,7 +459,11 @@ export default function MinecraftMultiColumnStatisticTable({
                                 gridColumn={`${index + 2}`}
                                 style={columnWidths ? { width: columnWidths[index + 1] || '120px' } : undefined}
                             >
-                                {typeof value === 'number' ? value.toFixed(1) : value}
+                                {valueFormatter
+                                    ? valueFormatter(value, index)
+                                    : typeof value === 'number'
+                                      ? value.toFixed(1)
+                                      : value}
                             </VSCodeDataGridCell>
                         ))}
                     </VSCodeDataGridRow>

--- a/webview-ui/src/diagnostics_panel/controls/MinecraftMultiColumnStatisticTable.tsx
+++ b/webview-ui/src/diagnostics_panel/controls/MinecraftMultiColumnStatisticTable.tsx
@@ -33,6 +33,8 @@ type MultiColumnTrackedStat = {
     time: number;
 };
 
+type NonConsolidatedColumnResolver = (event: StatisticUpdatedMessage, valueLabels: string[]) => number | undefined;
+
 type MinecraftMultiColumnStatisticTableProps = {
     title: string;
     statisticDataProvider: MultipleStatisticProvider;
@@ -46,6 +48,7 @@ type MinecraftMultiColumnStatisticTableProps = {
     prettifyNames?: boolean; // Whether to format packet names (camelCase -> Camel Case) or keep original format
     columnWidths?: string[]; // Optional array of column widths (first is key column, rest are value columns)
     actions?: { label: string; onClick: () => void }[]; // Optional actions with labels and commands to run on click
+    nonConsolidatedColumnResolver?: NonConsolidatedColumnResolver; // Maps split events to target columns for non-consolidated streams
 };
 
 const sortOrderOptions = [
@@ -64,7 +67,8 @@ function processChildrenStringValues(
     categoryMap: Map<string, MultiColumnTrackedStat>,
     valueLabels: string[],
     prettifyNames: boolean,
-    eventTime: number
+    eventTime: number,
+    targetColumnIndex?: number,
 ): void {
     children_string_values.forEach(childRow => {
         if (childRow.length >= 2) {
@@ -91,9 +95,22 @@ function processChildrenStringValues(
                       .split('::')
                       .pop()
                       ?.replace(/([a-z])([A-Z])/g, '$1 $2') // Add spaces before capital letters
-                      ?.replace(/^./, (str: string) => str.toUpperCase()) || // Capitalize first letter
-                  packetName
+                      ?.replace(/^./, (str: string) => str.toUpperCase()) || packetName // Capitalize first letter
                 : packetName.split('::').pop() || packetName;
+
+            if (targetColumnIndex !== undefined && values.length === 1 && valueLabels.length > 1) {
+                const existingValues = categoryMap.get(cleanPacketName)?.values ?? Array(valueLabels.length).fill('');
+                const mergedValues = [...existingValues];
+                mergedValues[targetColumnIndex] = values[0];
+
+                categoryMap.set(cleanPacketName, {
+                    category: cleanPacketName,
+                    values: mergedValues,
+                    time: eventTime,
+                });
+
+                return;
+            }
 
             categoryMap.set(cleanPacketName, {
                 category: cleanPacketName,
@@ -116,7 +133,17 @@ export default function MinecraftMultiColumnStatisticTable({
     prettifyNames = true, // Default to prettifying names for backward compatibility
     columnWidths,
     actions,
+    nonConsolidatedColumnResolver,
 }: MinecraftMultiColumnStatisticTableProps): JSX.Element {
+    // Memoize sort column options to prevent unnecessary recreations
+    const sortColumnOptions = useMemo(
+        () => [
+            { id: MinecraftMultiColumnStatisticTableSortColumn.Key, label: keyLabel },
+            ...valueLabels.map((label, index) => ({ id: `value_${index}`, label })),
+        ],
+        [keyLabel, valueLabels],
+    );
+
     // states
     const [data, setData] = useState<MultiColumnTrackedStat[]>([]);
     const [selectedSortOrder, setSelectedSortOrder] =
@@ -124,56 +151,83 @@ export default function MinecraftMultiColumnStatisticTable({
     const [selectedSortType, setSelectedSortType] =
         useState<MinecraftMultiColumnStatisticTableSortType>(defaultSortType);
     const [selectedSortColumn, setSelectedSortColumn] = useState<string>(
-        defaultSortColumn || MinecraftMultiColumnStatisticTableSortColumn.Key
-    );
-
-    // Memoize sort column options to prevent unnecessary recreations
-    const sortColumnOptions = useMemo(
-        () => [
-            { id: MinecraftMultiColumnStatisticTableSortColumn.Key, label: keyLabel },
-            ...valueLabels.map((label, index) => ({ id: `value_${index}`, label })),
-        ],
-        [keyLabel, valueLabels]
+        defaultSortColumn || MinecraftMultiColumnStatisticTableSortColumn.Key,
     );
 
     const _onSelectedSortOrderChange = useCallback((e: Event | React.FormEvent<HTMLElement>): void => {
         const target = e.target as HTMLSelectElement;
-        setSelectedSortOrder(sortOrderOptions[target.selectedIndex].id);
+        setSelectedSortOrder(Number(target.value));
     }, []);
 
     const _onSelectedSortTypeChange = useCallback((e: Event | React.FormEvent<HTMLElement>): void => {
         const target = e.target as HTMLSelectElement;
-        setSelectedSortType(sortTypeOptions[target.selectedIndex].id);
+        setSelectedSortType(Number(target.value));
     }, []);
 
-    const _onSelectedSortColumnChange = useCallback(
-        (e: Event | React.FormEvent<HTMLElement>): void => {
-            const target = e.target as HTMLSelectElement;
-            setSelectedSortColumn(sortColumnOptions[target.selectedIndex].id);
-        },
-        [sortColumnOptions]
-    );
+    const _onSelectedSortColumnChange = useCallback((e: Event | React.FormEvent<HTMLElement>): void => {
+        const target = e.target as HTMLSelectElement;
+        setSelectedSortColumn(target.value);
+    }, []);
+
+    useEffect(() => {
+        setSelectedSortOrder(defaultSortOrder);
+    }, [defaultSortOrder]);
+
+    useEffect(() => {
+        setSelectedSortType(defaultSortType);
+    }, [defaultSortType]);
+
+    useEffect(() => {
+        setSelectedSortColumn(defaultSortColumn || MinecraftMultiColumnStatisticTableSortColumn.Key);
+    }, [defaultSortColumn]);
 
     useEffect(() => {
         const eventHandler = (event: StatisticUpdatedMessage): void => {
             // Update data with new data point
-            setData((_prevState: MultiColumnTrackedStat[]): MultiColumnTrackedStat[] => {
-                // Group stats by category and collect values
+            setData((prevState: MultiColumnTrackedStat[]): MultiColumnTrackedStat[] => {
+                const isConsolidatedDataEvent =
+                    event.id === 'consolidated_data' &&
+                    event.children_string_values &&
+                    event.children_string_values.length > 0;
+
+                // Group stats by category and collect values. For split metric streams,
+                // preserve previous rows and merge in only the updated column.
                 const categoryMap = new Map<string, MultiColumnTrackedStat>();
+
+                if (!isConsolidatedDataEvent) {
+                    prevState.forEach(previousRow => {
+                        categoryMap.set(previousRow.category, {
+                            category: previousRow.category,
+                            values: [...previousRow.values],
+                            time: previousRow.time,
+                        });
+                    });
+                }
+
+                const valueColumnIndex = isConsolidatedDataEvent
+                    ? undefined
+                    : nonConsolidatedColumnResolver?.(event, valueLabels);
+
+                if (!isConsolidatedDataEvent && valueColumnIndex === undefined) {
+                    if (import.meta.env.DEV) {
+                        console.warn(
+                            `Skipping non-consolidated event with unmapped column id=${event.id} name=${event.name}`,
+                        );
+                    }
+
+                    return Array.from(categoryMap.values());
+                }
 
                 // For consolidated_data events with children_string_values, skip the statisticResolver
                 // and process the data directly since it's already in the correct format
-                if (
-                    event.id === 'consolidated_data' &&
-                    event.children_string_values &&
-                    event.children_string_values.length > 0
-                ) {
+                if (isConsolidatedDataEvent) {
                     processChildrenStringValues(
                         event.children_string_values,
                         categoryMap,
                         valueLabels,
                         prettifyNames,
-                        event.time || Date.now()
+                        event.time || Date.now(),
+                        valueColumnIndex,
                     );
                 } else {
                     // Use the statisticResolver for other event types
@@ -190,19 +244,18 @@ export default function MinecraftMultiColumnStatisticTable({
                             while (existing.values.length < valueLabels.length) {
                                 existing.values.push(0);
                             }
-                            existing.values[existing.values.length - 1] = stat.absoluteValue;
+                            const targetColumn = valueColumnIndex as number;
+                            existing.values[targetColumn] = stat.absoluteValue;
                             existing.time = Math.max(existing.time, stat.time);
                         } else {
                             // Create new entry
                             const newStat: MultiColumnTrackedStat = {
                                 category: stat.category,
-                                values: [stat.absoluteValue],
+                                values: Array(valueLabels.length).fill(0),
                                 time: stat.time,
                             };
-                            // Pad values array to match number of columns
-                            while (newStat.values.length < valueLabels.length) {
-                                newStat.values.push(0);
-                            }
+                            const targetColumn = valueColumnIndex as number;
+                            newStat.values[targetColumn] = stat.absoluteValue;
                             categoryMap.set(stat.category, newStat);
                         }
                     });
@@ -214,7 +267,8 @@ export default function MinecraftMultiColumnStatisticTable({
                             categoryMap,
                             valueLabels,
                             prettifyNames,
-                            event.time || Date.now()
+                            event.time || Date.now(),
+                            valueColumnIndex,
                         );
                     }
                 }
@@ -322,36 +376,34 @@ export default function MinecraftMultiColumnStatisticTable({
                     <VSCodeDropdown
                         id="sort-order"
                         onChange={_onSelectedSortOrderChange}
-                        defaultValue={sortOrderOptions.findIndex(elem => elem.id === selectedSortOrder)}
+                        value={`${selectedSortOrder}`}
                     >
                         {sortOrderOptions.map(sortOption => (
-                            <VSCodeOption key={sortOption.id}>{sortOption.label}</VSCodeOption>
+                            <VSCodeOption key={sortOption.id} value={`${sortOption.id}`}>
+                                {sortOption.label}
+                            </VSCodeOption>
                         ))}
                     </VSCodeDropdown>
                 </div>
                 <div style={{ width: '10px' }}></div>
                 <div className="minecraft-statistic-table-sort-container">
                     <label htmlFor="sort-type">Sort Type</label>
-                    <VSCodeDropdown
-                        id="sort-type"
-                        onChange={_onSelectedSortTypeChange}
-                        defaultValue={sortTypeOptions.findIndex(elem => elem.id === selectedSortType)}
-                    >
+                    <VSCodeDropdown id="sort-type" onChange={_onSelectedSortTypeChange} value={`${selectedSortType}`}>
                         {sortTypeOptions.map(sortOption => (
-                            <VSCodeOption key={sortOption.id}>{sortOption.label}</VSCodeOption>
+                            <VSCodeOption key={sortOption.id} value={`${sortOption.id}`}>
+                                {sortOption.label}
+                            </VSCodeOption>
                         ))}
                     </VSCodeDropdown>
                 </div>
                 <div style={{ width: '10px' }}></div>
                 <div className="minecraft-statistic-table-sort-container">
                     <label htmlFor="sort-column">Sort Column</label>
-                    <VSCodeDropdown
-                        id="sort-column"
-                        onChange={_onSelectedSortColumnChange}
-                        defaultValue={sortColumnOptions.findIndex(elem => elem.id === selectedSortColumn)}
-                    >
+                    <VSCodeDropdown id="sort-column" onChange={_onSelectedSortColumnChange} value={selectedSortColumn}>
                         {sortColumnOptions.map(sortOption => (
-                            <VSCodeOption key={sortOption.id}>{sortOption.label}</VSCodeOption>
+                            <VSCodeOption key={sortOption.id} value={sortOption.id}>
+                                {sortOption.label}
+                            </VSCodeOption>
                         ))}
                     </VSCodeDropdown>
                 </div>

--- a/webview-ui/src/diagnostics_panel/prefabs/index.tsx
+++ b/webview-ui/src/diagnostics_panel/prefabs/index.tsx
@@ -11,6 +11,7 @@ import serverScriptSubscriberCountsTab from './tabs/ServerScriptSubscriberCounts
 
 import clientTimingTab from './tabs/ClientTiming';
 import clientMemoryTab from './tabs/ClientMemory';
+import clientEntitySystemTab from './tabs/ClientEntitySystems';
 
 import editorNetworkStatsTab from './tabs/EditorNetworkStats';
 
@@ -24,6 +25,7 @@ export default [
     serverScriptSubscriberCountsTab,
     clientTimingTab,
     clientMemoryTab,
+    clientEntitySystemTab,
     dynamicPropertyTab,
     editorNetworkStatsTab,
 ];

--- a/webview-ui/src/diagnostics_panel/prefabs/tabs/ClientEntitySystems.tsx
+++ b/webview-ui/src/diagnostics_panel/prefabs/tabs/ClientEntitySystems.tsx
@@ -5,6 +5,21 @@ import MinecraftMultiColumnStatisticTable, {
     MinecraftMultiColumnStatisticTableSortOrder,
     MinecraftMultiColumnStatisticTableSortType,
 } from '../../controls/MinecraftMultiColumnStatisticTable';
+import {
+    DebuggerRequestResultMessage,
+    getDebuggerRequestResult,
+    isDebuggerRequestInFlight,
+    sendDebuggerRequest,
+    useDebuggerRequestUpdates,
+} from '../../utilities/useDebuggerRequests';
+import { useState } from 'react';
+import { VSCodeButton } from '@vscode/webview-ui-toolkit/react';
+
+const DEBUGGER_REQUEST_COMMANDS = [
+    { command: 'Start Entity System Profiler', label: 'Start' },
+    { command: 'Stop Entity System Profiler', label: 'Stop' },
+    { command: 'Clear Entity System Profiler', label: 'Clear' },
+];
 
 function resolveEcsColumn(eventId: string): number | undefined {
     switch (eventId) {
@@ -17,69 +32,116 @@ function resolveEcsColumn(eventId: string): number | undefined {
     }
 }
 
+function lastResultToUserFriendlyString(lastResult: DebuggerRequestResultMessage): string {
+    if (lastResult.error) {
+        return `Error: ${lastResult.error}`;
+    } else if (lastResult.response) {
+        if (lastResult.response.success) {
+            return `${lastResult.response.response_message}`;
+        } else {
+            return `Failed: ${lastResult.response.response_message}`;
+        }
+    } else {
+        return 'Press Start to Begin Profiling';
+    }
+}
+
 const statsTab: TabPrefab = {
     name: 'Client - Entity Systems',
     dataSource: TabPrefabDataSource.Client,
     content: ({ selectedClient }: TabPrefabParams) => {
+        useDebuggerRequestUpdates();
+        const [lastRequestedCommand, setLastRequestedCommand] = useState<string>('');
+
+        const lastResult: DebuggerRequestResultMessage | undefined = lastRequestedCommand
+            ? getDebuggerRequestResult(lastRequestedCommand)
+            : undefined;
+
         return (
-            <div style={{ flexDirection: 'column', display: 'flex', width: '100%' }}>
-                <label style={{ fontSize: '14px', fontStyle: 'italic', marginTop: '10px' }}>
-                    Entity and System timings can be collected by enabling the profiler with the `/ecsprof start`
-                    command.
-                </label>
-                <div style={{ flex: 1, marginRight: '5px' }}>
-                    <MinecraftMultiColumnStatisticTable
-                        title="Entity Timings"
-                        keyLabel="Entity"
-                        valueLabels={['Time In Nanoseconds', 'Percent Of Total']}
-                        statisticDataProvider={
-                            new MultipleStatisticProvider({
-                                statisticIds: ['time_in_ns', 'percent_of_total'],
-                                statisticParentId: new RegExp(`.*${selectedClient}_client_ecs_entities`),
-                            })
-                        }
-                        statisticResolver={ParentNameStatResolver(
-                            createStatResolver({
-                                type: StatisticType.Absolute,
-                                tickRange: 20 * 10,
-                                yAxisType: YAxisType.Absolute,
-                                valueScalar: 1,
-                            }),
-                        )}
-                        defaultSortColumn="value_1"
-                        defaultSortOrder={MinecraftMultiColumnStatisticTableSortOrder.Descending}
-                        defaultSortType={MinecraftMultiColumnStatisticTableSortType.Numerical}
-                        columnWidths={['auto', 'auto']}
-                        prettifyNames={false}
-                        nonConsolidatedColumnResolver={event => resolveEcsColumn(event.id)}
-                    />
+            <div>
+                <div style={{ flexDirection: 'column', display: 'flex', width: '25%' }}>
+                    <div style={{ flex: 1, margin: '5px' }}>
+                        <h2>Entity System Profiler Controls</h2>
+                        {DEBUGGER_REQUEST_COMMANDS.map(command => {
+                            const inFlight = isDebuggerRequestInFlight(command.command);
+                            return (
+                                <VSCodeButton
+                                    key={command.command}
+                                    disabled={inFlight}
+                                    onClick={() => {
+                                        setLastRequestedCommand(command.command);
+                                        sendDebuggerRequest(command.command);
+                                    }}
+                                    style={{ margin: '5px' }}
+                                >
+                                    {command.label}
+                                </VSCodeButton>
+                            );
+                        })}
+                        <div style={{ marginTop: '20px' }}>
+                            <text style={{ fontStyle: 'italic' }}>
+                                {lastResult
+                                    ? lastResultToUserFriendlyString(lastResult)
+                                    : 'Press Start to Begin Profiling'}
+                            </text>
+                        </div>
+                    </div>
                 </div>
-                <div style={{ flex: 1, marginRight: '5px' }}>
-                    <MinecraftMultiColumnStatisticTable
-                        title="System Timings"
-                        keyLabel="System"
-                        valueLabels={['Time In Nanoseconds', 'Percent Of Total']}
-                        statisticDataProvider={
-                            new MultipleStatisticProvider({
-                                statisticIds: ['time_in_ns', 'percent_of_total'],
-                                statisticParentId: new RegExp(`.*${selectedClient}_client_ecs_systems`),
-                            })
-                        }
-                        statisticResolver={ParentNameStatResolver(
-                            createStatResolver({
-                                type: StatisticType.Absolute,
-                                tickRange: 20 * 10,
-                                yAxisType: YAxisType.Absolute,
-                                valueScalar: 1,
-                            }),
-                        )}
-                        defaultSortColumn="value_1"
-                        defaultSortOrder={MinecraftMultiColumnStatisticTableSortOrder.Descending}
-                        defaultSortType={MinecraftMultiColumnStatisticTableSortType.Numerical}
-                        columnWidths={['auto', 'auto']}
-                        prettifyNames={false}
-                        nonConsolidatedColumnResolver={event => resolveEcsColumn(event.id)}
-                    />
+                <div style={{ flexDirection: 'row', display: 'flex', width: '100%' }}>
+                    <div style={{ flex: 1, marginRight: '5px' }}>
+                        <MinecraftMultiColumnStatisticTable
+                            title="Entity Timings"
+                            keyLabel="Entity"
+                            valueLabels={['Time In Nanoseconds', 'Percent Of Total']}
+                            statisticDataProvider={
+                                new MultipleStatisticProvider({
+                                    statisticIds: ['time_in_ns', 'percent_of_total'],
+                                    statisticParentId: new RegExp(`.*${selectedClient}_client_ecs_entities`),
+                                })
+                            }
+                            statisticResolver={ParentNameStatResolver(
+                                createStatResolver({
+                                    type: StatisticType.Absolute,
+                                    tickRange: 20 * 10,
+                                    yAxisType: YAxisType.Absolute,
+                                    valueScalar: 1,
+                                }),
+                            )}
+                            defaultSortColumn="value_1"
+                            defaultSortOrder={MinecraftMultiColumnStatisticTableSortOrder.Descending}
+                            defaultSortType={MinecraftMultiColumnStatisticTableSortType.Numerical}
+                            columnWidths={['auto', 'auto']}
+                            prettifyNames={false}
+                            nonConsolidatedColumnResolver={event => resolveEcsColumn(event.id)}
+                        />
+                    </div>
+                    <div style={{ flex: 1, marginRight: '5px' }}>
+                        <MinecraftMultiColumnStatisticTable
+                            title="System Timings"
+                            keyLabel="System"
+                            valueLabels={['Time In Nanoseconds', 'Percent Of Total']}
+                            statisticDataProvider={
+                                new MultipleStatisticProvider({
+                                    statisticIds: ['time_in_ns', 'percent_of_total'],
+                                    statisticParentId: new RegExp(`.*${selectedClient}_client_ecs_systems`),
+                                })
+                            }
+                            statisticResolver={ParentNameStatResolver(
+                                createStatResolver({
+                                    type: StatisticType.Absolute,
+                                    tickRange: 20 * 10,
+                                    yAxisType: YAxisType.Absolute,
+                                    valueScalar: 1,
+                                }),
+                            )}
+                            defaultSortColumn="value_1"
+                            defaultSortOrder={MinecraftMultiColumnStatisticTableSortOrder.Descending}
+                            defaultSortType={MinecraftMultiColumnStatisticTableSortType.Numerical}
+                            columnWidths={['auto', 'auto']}
+                            prettifyNames={false}
+                            nonConsolidatedColumnResolver={event => resolveEcsColumn(event.id)}
+                        />
+                    </div>
                 </div>
             </div>
         );

--- a/webview-ui/src/diagnostics_panel/prefabs/tabs/ClientEntitySystems.tsx
+++ b/webview-ui/src/diagnostics_panel/prefabs/tabs/ClientEntitySystems.tsx
@@ -1,0 +1,89 @@
+import { MultipleStatisticProvider } from '../../StatisticProvider';
+import { ParentNameStatResolver, StatisticType, YAxisType, createStatResolver } from '../../StatisticResolver';
+import { TabPrefab, TabPrefabDataSource, TabPrefabParams } from '../TabPrefab';
+import MinecraftMultiColumnStatisticTable, {
+    MinecraftMultiColumnStatisticTableSortOrder,
+    MinecraftMultiColumnStatisticTableSortType,
+} from '../../controls/MinecraftMultiColumnStatisticTable';
+
+function resolveEcsColumn(eventId: string): number | undefined {
+    switch (eventId) {
+        case 'time_in_ns':
+            return 0;
+        case 'percent_of_total':
+            return 1;
+        default:
+            return undefined;
+    }
+}
+
+const statsTab: TabPrefab = {
+    name: 'Client - Entity Systems',
+    dataSource: TabPrefabDataSource.Client,
+    content: ({ selectedClient }: TabPrefabParams) => {
+        return (
+            <div style={{ flexDirection: 'column', display: 'flex', width: '100%' }}>
+                <label style={{ fontSize: '14px', fontStyle: 'italic', marginTop: '10px' }}>
+                    Entity and System timings can be collected by enabling the profiler with the `/ecsprof start`
+                    command.
+                </label>
+                <div style={{ flex: 1, marginRight: '5px' }}>
+                    <MinecraftMultiColumnStatisticTable
+                        title="Entity Timings"
+                        keyLabel="Entity"
+                        valueLabels={['Time In Nanoseconds', 'Percent Of Total']}
+                        statisticDataProvider={
+                            new MultipleStatisticProvider({
+                                statisticIds: ['time_in_ns', 'percent_of_total'],
+                                statisticParentId: new RegExp(`.*${selectedClient}_client_ecs_entities`),
+                            })
+                        }
+                        statisticResolver={ParentNameStatResolver(
+                            createStatResolver({
+                                type: StatisticType.Absolute,
+                                tickRange: 20 * 10,
+                                yAxisType: YAxisType.Absolute,
+                                valueScalar: 1,
+                            }),
+                        )}
+                        defaultSortColumn="value_1"
+                        defaultSortOrder={MinecraftMultiColumnStatisticTableSortOrder.Descending}
+                        defaultSortType={MinecraftMultiColumnStatisticTableSortType.Numerical}
+                        columnWidths={['auto', 'auto']}
+                        prettifyNames={false}
+                        nonConsolidatedColumnResolver={event => resolveEcsColumn(event.id)}
+                    />
+                </div>
+                <div style={{ flex: 1, marginRight: '5px' }}>
+                    <MinecraftMultiColumnStatisticTable
+                        title="System Timings"
+                        keyLabel="System"
+                        valueLabels={['Time In Nanoseconds', 'Percent Of Total']}
+                        statisticDataProvider={
+                            new MultipleStatisticProvider({
+                                statisticIds: ['time_in_ns', 'percent_of_total'],
+                                statisticParentId: new RegExp(`.*${selectedClient}_client_ecs_systems`),
+                            })
+                        }
+                        statisticResolver={ParentNameStatResolver(
+                            createStatResolver({
+                                type: StatisticType.Absolute,
+                                tickRange: 20 * 10,
+                                yAxisType: YAxisType.Absolute,
+                                valueScalar: 1,
+                            }),
+                        )}
+                        defaultSortColumn="value_1"
+                        defaultSortOrder={MinecraftMultiColumnStatisticTableSortOrder.Descending}
+                        defaultSortType={MinecraftMultiColumnStatisticTableSortType.Numerical}
+                        columnWidths={['auto', 'auto']}
+                        prettifyNames={false}
+                        nonConsolidatedColumnResolver={event => resolveEcsColumn(event.id)}
+                    />
+                </div>
+            </div>
+        );
+    },
+};
+
+export default statsTab;

--- a/webview-ui/src/diagnostics_panel/prefabs/tabs/ClientEntitySystems.tsx
+++ b/webview-ui/src/diagnostics_panel/prefabs/tabs/ClientEntitySystems.tsx
@@ -120,6 +120,13 @@ const statsTab: TabPrefab = {
                                 </VSCodeButton>
                             );
                         })}
+                        <div style={{ marginTop: '20px' }}>
+                            <text style={{ fontStyle: 'italic' }}>
+                                {lastResult
+                                    ? lastResultToUserFriendlyString(lastResult)
+                                    : 'Press Start to Begin Profiling'}
+                            </text>
+                        </div>
                         <div style={{ marginTop: '10px', display: 'flex', flexDirection: 'column' }}>
                             <label htmlFor="ecs-timing-unit" style={{ marginBottom: '5px' }}>
                                 Timing Unit
@@ -136,13 +143,6 @@ const statsTab: TabPrefab = {
                                 <VSCodeOption value="us">Microseconds</VSCodeOption>
                                 <VSCodeOption value="ms">Milliseconds</VSCodeOption>
                             </VSCodeDropdown>
-                        </div>
-                        <div style={{ marginTop: '20px' }}>
-                            <text style={{ fontStyle: 'italic' }}>
-                                {lastResult
-                                    ? lastResultToUserFriendlyString(lastResult)
-                                    : 'Press Start to Begin Profiling'}
-                            </text>
                         </div>
                     </div>
                 </div>

--- a/webview-ui/src/diagnostics_panel/prefabs/tabs/ClientEntitySystems.tsx
+++ b/webview-ui/src/diagnostics_panel/prefabs/tabs/ClientEntitySystems.tsx
@@ -13,13 +13,49 @@ import {
     useDebuggerRequestUpdates,
 } from '../../utilities/useDebuggerRequests';
 import { useState } from 'react';
-import { VSCodeButton } from '@vscode/webview-ui-toolkit/react';
+import { VSCodeButton, VSCodeDropdown, VSCodeOption } from '@vscode/webview-ui-toolkit/react';
 
 const DEBUGGER_REQUEST_COMMANDS = [
     { command: 'Start Entity System Profiler', label: 'Start' },
     { command: 'Stop Entity System Profiler', label: 'Stop' },
     { command: 'Clear Entity System Profiler', label: 'Clear' },
 ];
+
+type TimingUnit = 'ns' | 'us' | 'ms';
+
+function ceilToThreeDecimalPlaces(value: number): number {
+    return Math.ceil(value * 1000) / 1000;
+}
+
+function getTimingColumnLabel(unit: TimingUnit): string {
+    if (unit === 'ms') {
+        return 'Time In Milliseconds';
+    }
+
+    if (unit === 'us') {
+        return 'Time In Microseconds';
+    }
+
+    return 'Time In Nanoseconds';
+}
+
+function formatTimingValue(value: string | number, unit: TimingUnit): string {
+    const numericValue = typeof value === 'number' ? value : Number(value);
+
+    if (!Number.isFinite(numericValue)) {
+        return unit === 'ns' ? '0' : '0.000';
+    }
+
+    if (unit === 'ms') {
+        return ceilToThreeDecimalPlaces(numericValue / 1_000_000).toFixed(3);
+    }
+
+    if (unit === 'us') {
+        return ceilToThreeDecimalPlaces(numericValue / 1_000).toFixed(3);
+    }
+
+    return `${Math.ceil(numericValue)}`;
+}
 
 function resolveEcsColumn(eventId: string): number | undefined {
     switch (eventId) {
@@ -53,6 +89,7 @@ const statsTab: TabPrefab = {
         useDebuggerRequestUpdates();
         const [lastRequestedCommand, setLastRequestedCommand] = useState<string>('');
         const [clearResetEpoch, setClearResetEpoch] = useState(0);
+        const [timingUnit, setTimingUnit] = useState<TimingUnit>('ns');
 
         const lastResult: DebuggerRequestResultMessage | undefined = lastRequestedCommand
             ? getDebuggerRequestResult(lastRequestedCommand)
@@ -83,6 +120,23 @@ const statsTab: TabPrefab = {
                                 </VSCodeButton>
                             );
                         })}
+                        <div style={{ marginTop: '10px', display: 'flex', flexDirection: 'column' }}>
+                            <label htmlFor="ecs-timing-unit" style={{ marginBottom: '5px' }}>
+                                Timing Unit
+                            </label>
+                            <VSCodeDropdown
+                                id="ecs-timing-unit"
+                                value={timingUnit}
+                                onChange={(event: Event | React.FormEvent<HTMLElement>) => {
+                                    const target = event.target as HTMLSelectElement;
+                                    setTimingUnit(target.value as TimingUnit);
+                                }}
+                            >
+                                <VSCodeOption value="ns">Nanoseconds</VSCodeOption>
+                                <VSCodeOption value="us">Microseconds</VSCodeOption>
+                                <VSCodeOption value="ms">Milliseconds</VSCodeOption>
+                            </VSCodeDropdown>
+                        </div>
                         <div style={{ marginTop: '20px' }}>
                             <text style={{ fontStyle: 'italic' }}>
                                 {lastResult
@@ -98,7 +152,7 @@ const statsTab: TabPrefab = {
                             key={`entity-timings-${selectedClient}-${clearResetEpoch}`}
                             title="Entity Timings"
                             keyLabel="Entity"
-                            valueLabels={['Time In Nanoseconds', 'Percent Of Total']}
+                            valueLabels={[getTimingColumnLabel(timingUnit), 'Percent Of Total']}
                             statisticDataProvider={
                                 new MultipleStatisticProvider({
                                     statisticIds: ['time_in_ns', 'percent_of_total'],
@@ -119,6 +173,13 @@ const statsTab: TabPrefab = {
                             columnWidths={['auto', 'auto']}
                             prettifyNames={false}
                             nonConsolidatedColumnResolver={event => resolveEcsColumn(event.id)}
+                            valueFormatter={(value, columnIndex) => {
+                                if (columnIndex === 0) {
+                                    return formatTimingValue(value, timingUnit);
+                                }
+
+                                return typeof value === 'number' ? value.toFixed(1) : String(value);
+                            }}
                         />
                     </div>
                     <div style={{ flex: 1, marginRight: '5px' }}>
@@ -126,7 +187,7 @@ const statsTab: TabPrefab = {
                             key={`system-timings-${selectedClient}-${clearResetEpoch}`}
                             title="System Timings"
                             keyLabel="System"
-                            valueLabels={['Time In Nanoseconds', 'Percent Of Total']}
+                            valueLabels={[getTimingColumnLabel(timingUnit), 'Percent Of Total']}
                             statisticDataProvider={
                                 new MultipleStatisticProvider({
                                     statisticIds: ['time_in_ns', 'percent_of_total'],
@@ -147,6 +208,13 @@ const statsTab: TabPrefab = {
                             columnWidths={['auto', 'auto']}
                             prettifyNames={false}
                             nonConsolidatedColumnResolver={event => resolveEcsColumn(event.id)}
+                            valueFormatter={(value, columnIndex) => {
+                                if (columnIndex === 0) {
+                                    return formatTimingValue(value, timingUnit);
+                                }
+
+                                return typeof value === 'number' ? value.toFixed(1) : String(value);
+                            }}
                         />
                     </div>
                 </div>

--- a/webview-ui/src/diagnostics_panel/prefabs/tabs/ClientEntitySystems.tsx
+++ b/webview-ui/src/diagnostics_panel/prefabs/tabs/ClientEntitySystems.tsx
@@ -52,6 +52,7 @@ const statsTab: TabPrefab = {
     content: ({ selectedClient }: TabPrefabParams) => {
         useDebuggerRequestUpdates();
         const [lastRequestedCommand, setLastRequestedCommand] = useState<string>('');
+        const [clearResetEpoch, setClearResetEpoch] = useState(0);
 
         const lastResult: DebuggerRequestResultMessage | undefined = lastRequestedCommand
             ? getDebuggerRequestResult(lastRequestedCommand)
@@ -69,6 +70,10 @@ const statsTab: TabPrefab = {
                                     key={command.command}
                                     disabled={inFlight}
                                     onClick={() => {
+                                        if (command.command === 'Clear Entity System Profiler') {
+                                            setClearResetEpoch(prev => prev + 1);
+                                        }
+
                                         setLastRequestedCommand(command.command);
                                         sendDebuggerRequest(command.command);
                                     }}
@@ -90,6 +95,7 @@ const statsTab: TabPrefab = {
                 <div style={{ flexDirection: 'row', display: 'flex', width: '100%' }}>
                     <div style={{ flex: 1, marginRight: '5px' }}>
                         <MinecraftMultiColumnStatisticTable
+                            key={`entity-timings-${selectedClient}-${clearResetEpoch}`}
                             title="Entity Timings"
                             keyLabel="Entity"
                             valueLabels={['Time In Nanoseconds', 'Percent Of Total']}
@@ -117,6 +123,7 @@ const statsTab: TabPrefab = {
                     </div>
                     <div style={{ flex: 1, marginRight: '5px' }}>
                         <MinecraftMultiColumnStatisticTable
+                            key={`system-timings-${selectedClient}-${clearResetEpoch}`}
                             title="System Timings"
                             keyLabel="System"
                             valueLabels={['Time In Nanoseconds', 'Percent Of Total']}

--- a/webview-ui/src/diagnostics_panel/prefabs/tabs/ClientEntitySystems.tsx
+++ b/webview-ui/src/diagnostics_panel/prefabs/tabs/ClientEntitySystems.tsx
@@ -15,8 +15,10 @@ import {
 import { useState } from 'react';
 import { VSCodeButton, VSCodeDropdown, VSCodeOption } from '@vscode/webview-ui-toolkit/react';
 
+const START_ENTITY_SYSTEM_PROFILER_REQUEST = 'Start Entity System Profiler';
+
 const DEBUGGER_REQUEST_COMMANDS = [
-    { command: 'Start Entity System Profiler', label: 'Start' },
+    { command: START_ENTITY_SYSTEM_PROFILER_REQUEST, label: 'Start' },
     { command: 'Stop Entity System Profiler', label: 'Stop' },
     { command: 'Clear Entity System Profiler', label: 'Clear' },
 ];
@@ -170,8 +172,30 @@ const statsTab: TabPrefab = {
                             defaultSortColumn="value_1"
                             defaultSortOrder={MinecraftMultiColumnStatisticTableSortOrder.Descending}
                             defaultSortType={MinecraftMultiColumnStatisticTableSortType.Numerical}
-                            columnWidths={['auto', 'auto']}
+                            columnWidths={['auto', 'auto', 'auto', '70px']}
                             prettifyNames={false}
+                            rowAction={{
+                                label: '🔍',
+                                headerLabel: 'Focus',
+                                width: '70px',
+                                disabled: () => isDebuggerRequestInFlight(START_ENTITY_SYSTEM_PROFILER_REQUEST),
+                                onClick: async row => {
+                                    setLastRequestedCommand(START_ENTITY_SYSTEM_PROFILER_REQUEST);
+
+                                    // given an entity name like: minecraft:arrow<> (2#262231)
+                                    // we want to extract the numeric id at the end (262231 in this case) to send to the profiler
+                                    const args = {
+                                        entityId: row.category.split('#')[1]?.replace(')', ''),
+                                    };
+                                    sendDebuggerRequest(START_ENTITY_SYSTEM_PROFILER_REQUEST, args);
+
+                                    // Wait for isDebuggerRequestInFlight to become false and then clear
+                                    while (isDebuggerRequestInFlight(START_ENTITY_SYSTEM_PROFILER_REQUEST)) {
+                                        await new Promise(resolve => setTimeout(resolve, 100));
+                                    }
+                                    setClearResetEpoch(prev => prev + 1);
+                                },
+                            }}
                             nonConsolidatedColumnResolver={event => resolveEcsColumn(event.id)}
                             valueFormatter={(value, columnIndex) => {
                                 if (columnIndex === 0) {
@@ -205,7 +229,7 @@ const statsTab: TabPrefab = {
                             defaultSortColumn="value_1"
                             defaultSortOrder={MinecraftMultiColumnStatisticTableSortOrder.Descending}
                             defaultSortType={MinecraftMultiColumnStatisticTableSortType.Numerical}
-                            columnWidths={['auto', 'auto']}
+                            columnWidths={['auto', 'auto', 'auto']}
                             prettifyNames={false}
                             nonConsolidatedColumnResolver={event => resolveEcsColumn(event.id)}
                             valueFormatter={(value, columnIndex) => {


### PR DESCRIPTION
This change adds a new `Client Entity Systems` tab for displaying Entity and System timing diagnostics coming from the ECS Profiler. 

To enable this data being visualized, support for non consolidated data was added to `MinecraftMulitColumnStatisticTable`. The existing table had issues with the data structure of my non consolidated data. It was unable to handle the separate columns and so an optional `nonConsolidatedColumnResolver` was added to map the event id's to their target columns and preserve their state as the data comes in.

Secondarily changes were made to support the default column sort type and column sort order. These were implemented but not working. 

I've confirmed that the changes don't break the existing usage of the multi column table used by the Editor Network Stats

<img width="1393" height="739" alt="ecs_prof" src="https://github.com/user-attachments/assets/183d0e6d-67b7-469a-86ac-3efa76930f5d" />
