### PR TITLE
feat: New grouped statistic view for use in the Client - Entity Systems view

### DIFF
--- a/webview-ui/src/diagnostics_panel/App.css
+++ b/webview-ui/src/diagnostics_panel/App.css
@@ -218,6 +218,88 @@ main {
   text-align: right;
 }
 
+.minecraft-grouped-statistic-table-root {
+  width: 100%;
+}
+
+.minecraft-grouped-statistic-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.minecraft-grouped-statistic-toolbar-group {
+  display: flex;
+  flex-direction: column;
+  min-width: 160px;
+}
+
+.minecraft-grouped-statistic-table-surface {
+  border: 1px solid var(--vscode-editorGroup-border);
+  border-radius: 6px;
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+
+.minecraft-grouped-statistic-table-grid {
+  width: 100%;
+  border-collapse: collapse;
+  table-layout: fixed;
+}
+
+.minecraft-grouped-statistic-table-grid th,
+.minecraft-grouped-statistic-table-grid td {
+  border-bottom: 1px solid var(--vscode-editorGroup-border);
+  padding: 8px 10px;
+  text-align: left;
+  vertical-align: middle;
+}
+
+.minecraft-grouped-statistic-table-grid th {
+  background: var(--vscode-editor-background);
+  font-weight: 600;
+}
+
+.minecraft-grouped-statistic-table-grid-numeric {
+  text-align: right !important;
+  white-space: nowrap;
+}
+
+.minecraft-grouped-statistic-table-grid-action {
+  text-align: center !important;
+  width: 90px;
+}
+
+.minecraft-grouped-statistic-group-row {
+  background: color-mix(in srgb, var(--vscode-list-activeSelectionBackground) 33%, var(--vscode-editor-background));
+}
+
+.minecraft-grouped-statistic-group-key {
+  margin-right: 6px;
+  font-weight: 600;
+}
+
+.minecraft-grouped-statistic-group-meta {
+  color: var(--vscode-descriptionForeground);
+}
+
+.minecraft-grouped-statistic-toggle {
+  border: none;
+  background: transparent;
+  color: var(--vscode-foreground);
+  cursor: pointer;
+  padding: 0;
+  margin-right: 6px;
+  width: 14px;
+  text-align: center;
+}
+
+.minecraft-grouped-statistic-child-key {
+  display: inline-block;
+  padding-left: 18px;
+}
+
 .minecraft-profiler-flame-stream-root {
   width: 100%;
   display: flex;

--- a/webview-ui/src/diagnostics_panel/controls/MinecraftGroupedStatisticTable.tsx
+++ b/webview-ui/src/diagnostics_panel/controls/MinecraftGroupedStatisticTable.tsx
@@ -374,21 +374,8 @@ export default function MinecraftGroupedStatisticTable({
                 }
 
                 const newestData = Array.from(categoryMap.values());
-                const latestTicks = new Map<string, number>();
 
-                newestData.forEach(dataPoint => {
-                    const currentTick = latestTicks.get(dataPoint.category) ?? 0;
-                    if (dataPoint.time > currentTick) {
-                        latestTicks.set(dataPoint.category, dataPoint.time);
-                    }
-                });
-
-                const filteredData = newestData.filter(dataPoint => {
-                    const latestTick = latestTicks.get(dataPoint.category);
-                    return latestTick !== undefined && latestTick === dataPoint.time;
-                });
-
-                filteredData.sort((left, right) => {
+                newestData.sort((left, right) => {
                     const compareValue = compareRows(
                         left,
                         right,
@@ -402,7 +389,7 @@ export default function MinecraftGroupedStatisticTable({
                         : -compareValue;
                 });
 
-                return filteredData;
+                return newestData;
             });
         };
 

--- a/webview-ui/src/diagnostics_panel/controls/MinecraftGroupedStatisticTable.tsx
+++ b/webview-ui/src/diagnostics_panel/controls/MinecraftGroupedStatisticTable.tsx
@@ -1,0 +1,725 @@
+import { useCallback, useEffect, useId, useMemo, useState } from 'react';
+import { MultipleStatisticProvider, StatisticUpdatedMessage } from '../StatisticProvider';
+import { StatisticResolver } from '../StatisticResolver';
+import { VSCodeButton, VSCodeDropdown, VSCodeOption } from '@vscode/webview-ui-toolkit/react';
+
+export enum MinecraftGroupedStatisticTableSortOrder {
+    Ascending,
+    Descending,
+}
+
+export enum MinecraftGroupedStatisticTableSortType {
+    Alphabetical,
+    Numerical,
+}
+
+export enum MinecraftGroupedStatisticTableSortColumn {
+    Key = 'key',
+}
+
+export enum MinecraftGroupedStatisticTableDisplayMode {
+    Grouped = 'grouped',
+    Flat = 'flat',
+}
+
+export enum MinecraftGroupedStatisticTableColumnAggregation {
+    Average = 'average',
+    Sum = 'sum',
+}
+
+type GroupedStatisticTableRow = {
+    category: string;
+    values: (string | number)[];
+    time: number;
+};
+
+type GroupedStatisticTableGroup = {
+    key: string;
+    rows: GroupedStatisticTableRow[];
+    count: number;
+    sums: number[];
+    averages: number[];
+};
+
+type GroupedStatisticTableRowAction = {
+    label: string;
+    onClick: (row: GroupedStatisticTableRow) => void;
+    disabled?: (row: GroupedStatisticTableRow) => boolean;
+    headerLabel?: string;
+    width?: string;
+};
+
+type NonConsolidatedColumnResolver = (event: StatisticUpdatedMessage, valueLabels: string[]) => number | undefined;
+
+type MinecraftGroupedStatisticTableProps = {
+    title: string;
+    showTitle?: boolean;
+    statisticDataProvider: MultipleStatisticProvider;
+    statisticResolver: StatisticResolver;
+    keyLabel: string;
+    valueLabels: string[];
+    getGroupKey?: (rowCategory: string) => string;
+    displayMode?: MinecraftGroupedStatisticTableDisplayMode;
+    groupColumnAggregations?: MinecraftGroupedStatisticTableColumnAggregation[];
+    groupCountLabel?: string;
+    defaultCollapsed?: boolean;
+    defaultSortOrder?: MinecraftGroupedStatisticTableSortOrder;
+    defaultSortType?: MinecraftGroupedStatisticTableSortType;
+    defaultSortColumn?: string;
+    rowAction?: GroupedStatisticTableRowAction;
+    nonConsolidatedColumnResolver?: NonConsolidatedColumnResolver;
+    valueFormatter?: (value: string | number, columnIndex: number) => string;
+    prettifyNames?: boolean;
+};
+
+const sortOrderOptions = [
+    { id: MinecraftGroupedStatisticTableSortOrder.Ascending, label: 'Ascending' },
+    { id: MinecraftGroupedStatisticTableSortOrder.Descending, label: 'Descending' },
+];
+
+const sortTypeOptions = [
+    { id: MinecraftGroupedStatisticTableSortType.Alphabetical, label: 'Alphabetical' },
+    { id: MinecraftGroupedStatisticTableSortType.Numerical, label: 'Numerical' },
+];
+
+function getColumnIndexFromSortColumn(sortColumn: string, valueLabelsLength: number): number | undefined {
+    const columnIndex = parseInt(sortColumn.replace('value_', ''));
+    if (isNaN(columnIndex) || columnIndex < 0 || columnIndex >= valueLabelsLength) {
+        return undefined;
+    }
+
+    return columnIndex;
+}
+
+function getNumericValue(value: string | number): number | undefined {
+    if (typeof value === 'number') {
+        return Number.isFinite(value) ? value : undefined;
+    }
+
+    const parsed = parseFloat(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function getGroupColumnAggregation(
+    columnIndex: number,
+    groupColumnAggregations: MinecraftGroupedStatisticTableColumnAggregation[],
+): MinecraftGroupedStatisticTableColumnAggregation {
+    return groupColumnAggregations[columnIndex] ?? MinecraftGroupedStatisticTableColumnAggregation.Average;
+}
+
+function getAggregatedGroupColumnValue(
+    group: GroupedStatisticTableGroup,
+    columnIndex: number,
+    groupColumnAggregations: MinecraftGroupedStatisticTableColumnAggregation[],
+): number {
+    const aggregation = getGroupColumnAggregation(columnIndex, groupColumnAggregations);
+
+    if (aggregation === MinecraftGroupedStatisticTableColumnAggregation.Sum) {
+        return group.sums[columnIndex] ?? 0;
+    }
+
+    return group.averages[columnIndex] ?? 0;
+}
+
+function compareRows(
+    a: GroupedStatisticTableRow,
+    b: GroupedStatisticTableRow,
+    selectedSortType: MinecraftGroupedStatisticTableSortType,
+    selectedSortColumn: string,
+    valueLabelsLength: number,
+): number {
+    if (selectedSortColumn === MinecraftGroupedStatisticTableSortColumn.Key) {
+        return a.category.localeCompare(b.category);
+    }
+
+    const columnIndex = getColumnIndexFromSortColumn(selectedSortColumn, valueLabelsLength);
+    if (columnIndex === undefined) {
+        return a.category.localeCompare(b.category);
+    }
+
+    const aValue = a.values[columnIndex] ?? '';
+    const bValue = b.values[columnIndex] ?? '';
+
+    if (selectedSortType === MinecraftGroupedStatisticTableSortType.Alphabetical) {
+        return String(aValue).localeCompare(String(bValue));
+    }
+
+    const aNumericValue = getNumericValue(aValue);
+    const bNumericValue = getNumericValue(bValue);
+
+    if (aNumericValue === undefined && bNumericValue === undefined) {
+        return String(aValue).localeCompare(String(bValue));
+    }
+
+    if (aNumericValue === undefined) {
+        return 1;
+    }
+
+    if (bNumericValue === undefined) {
+        return -1;
+    }
+
+    return aNumericValue - bNumericValue;
+}
+
+function processChildrenStringValues(
+    childrenStringValues: string[][],
+    categoryMap: Map<string, GroupedStatisticTableRow>,
+    valueLabels: string[],
+    prettifyNames: boolean,
+    eventTime: number,
+    targetColumnIndex?: number,
+): void {
+    childrenStringValues.forEach(childRow => {
+        if (childRow.length < 2) {
+            return;
+        }
+
+        const rowName = childRow[0];
+        const values: (string | number)[] = [];
+
+        for (let i = 1; i < childRow.length; i += 1) {
+            const rawValue = childRow[i];
+            const numericValue = parseFloat(rawValue);
+            values.push(isNaN(numericValue) ? rawValue : numericValue);
+        }
+
+        while (values.length < valueLabels.length) {
+            values.push('');
+        }
+
+        const cleanRowName = prettifyNames
+            ? rowName
+                  .split('::')
+                  .pop()
+                  ?.replace(/([a-z])([A-Z])/g, '$1 $2')
+                  ?.replace(/^./, (character: string) => character.toUpperCase()) || rowName
+            : rowName.split('::').pop() || rowName;
+
+        if (targetColumnIndex !== undefined && values.length === 1 && valueLabels.length > 1) {
+            const existingValues = categoryMap.get(cleanRowName)?.values ?? Array(valueLabels.length).fill('');
+            const mergedValues = [...existingValues];
+            mergedValues[targetColumnIndex] = values[0];
+
+            categoryMap.set(cleanRowName, {
+                category: cleanRowName,
+                values: mergedValues,
+                time: eventTime,
+            });
+
+            return;
+        }
+
+        categoryMap.set(cleanRowName, {
+            category: cleanRowName,
+            values,
+            time: eventTime,
+        });
+    });
+}
+
+export default function MinecraftGroupedStatisticTable({
+    title,
+    showTitle = true,
+    statisticDataProvider,
+    statisticResolver,
+    keyLabel,
+    valueLabels,
+    getGroupKey,
+    displayMode = MinecraftGroupedStatisticTableDisplayMode.Grouped,
+    groupColumnAggregations = [],
+    groupCountLabel = 'entities',
+    defaultCollapsed = true,
+    defaultSortOrder = MinecraftGroupedStatisticTableSortOrder.Descending,
+    defaultSortType = MinecraftGroupedStatisticTableSortType.Numerical,
+    defaultSortColumn,
+    rowAction,
+    nonConsolidatedColumnResolver,
+    valueFormatter,
+    prettifyNames = false,
+}: MinecraftGroupedStatisticTableProps): JSX.Element {
+    const sortColumnOptions = useMemo(
+        () => [
+            { id: MinecraftGroupedStatisticTableSortColumn.Key, label: keyLabel },
+            ...valueLabels.map((label, index) => ({ id: `value_${index}`, label })),
+        ],
+        [keyLabel, valueLabels],
+    );
+
+    const [data, setData] = useState<GroupedStatisticTableRow[]>([]);
+    const [selectedSortOrder, setSelectedSortOrder] =
+        useState<MinecraftGroupedStatisticTableSortOrder>(defaultSortOrder);
+    const [selectedSortType, setSelectedSortType] = useState<MinecraftGroupedStatisticTableSortType>(defaultSortType);
+    const [selectedSortColumn, setSelectedSortColumn] = useState<string>(
+        defaultSortColumn || MinecraftGroupedStatisticTableSortColumn.Key,
+    );
+    const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
+    const isGroupedMode = displayMode === MinecraftGroupedStatisticTableDisplayMode.Grouped;
+    const groupKeyResolver = getGroupKey ?? ((rowCategory: string) => rowCategory);
+
+    const controlIdBase = useId().replace(/:/g, '');
+
+    const onSelectedSortOrderChange = useCallback((event: Event | React.FormEvent<HTMLElement>): void => {
+        const target = event.target as HTMLSelectElement;
+        setSelectedSortOrder(Number(target.value));
+    }, []);
+
+    const onSelectedSortTypeChange = useCallback((event: Event | React.FormEvent<HTMLElement>): void => {
+        const target = event.target as HTMLSelectElement;
+        setSelectedSortType(Number(target.value));
+    }, []);
+
+    const onSelectedSortColumnChange = useCallback((event: Event | React.FormEvent<HTMLElement>): void => {
+        const target = event.target as HTMLSelectElement;
+        setSelectedSortColumn(target.value);
+    }, []);
+
+    const onToggleGroup = useCallback((groupKey: string): void => {
+        setExpandedGroups(previousExpandedGroups => {
+            const updated = new Set(previousExpandedGroups);
+
+            if (updated.has(groupKey)) {
+                updated.delete(groupKey);
+            } else {
+                updated.add(groupKey);
+            }
+
+            return updated;
+        });
+    }, []);
+
+    useEffect(() => {
+        setSelectedSortOrder(defaultSortOrder);
+    }, [defaultSortOrder]);
+
+    useEffect(() => {
+        setSelectedSortType(defaultSortType);
+    }, [defaultSortType]);
+
+    useEffect(() => {
+        setSelectedSortColumn(defaultSortColumn || MinecraftGroupedStatisticTableSortColumn.Key);
+    }, [defaultSortColumn]);
+
+    useEffect(() => {
+        const eventHandler = (event: StatisticUpdatedMessage): void => {
+            setData(previousState => {
+                const isConsolidatedDataEvent =
+                    event.id === 'consolidated_data' &&
+                    event.children_string_values &&
+                    event.children_string_values.length > 0;
+
+                const categoryMap = new Map<string, GroupedStatisticTableRow>();
+
+                if (!isConsolidatedDataEvent) {
+                    previousState.forEach(previousRow => {
+                        categoryMap.set(previousRow.category, {
+                            category: previousRow.category,
+                            values: [...previousRow.values],
+                            time: previousRow.time,
+                        });
+                    });
+                }
+
+                const valueColumnIndex = isConsolidatedDataEvent
+                    ? undefined
+                    : nonConsolidatedColumnResolver?.(event, valueLabels);
+
+                if (!isConsolidatedDataEvent && valueColumnIndex === undefined) {
+                    if (import.meta.env.DEV) {
+                        console.warn(
+                            `Skipping non-consolidated event with unmapped column id=${event.id} name=${event.name}`,
+                        );
+                    }
+
+                    return Array.from(categoryMap.values());
+                }
+
+                if (isConsolidatedDataEvent) {
+                    processChildrenStringValues(
+                        event.children_string_values,
+                        categoryMap,
+                        valueLabels,
+                        prettifyNames,
+                        event.time || Date.now(),
+                        valueColumnIndex,
+                    );
+                } else {
+                    const rawStats = statisticResolver(event, []);
+
+                    rawStats.forEach(stat => {
+                        if (!stat.category) {
+                            return;
+                        }
+
+                        const existing = categoryMap.get(stat.category);
+                        if (existing) {
+                            while (existing.values.length < valueLabels.length) {
+                                existing.values.push(0);
+                            }
+
+                            const targetColumn = valueColumnIndex as number;
+                            existing.values[targetColumn] = stat.absoluteValue;
+                            existing.time = Math.max(existing.time, stat.time);
+                        } else {
+                            const created: GroupedStatisticTableRow = {
+                                category: stat.category,
+                                values: Array(valueLabels.length).fill(0),
+                                time: stat.time,
+                            };
+
+                            const targetColumn = valueColumnIndex as number;
+                            created.values[targetColumn] = stat.absoluteValue;
+                            categoryMap.set(stat.category, created);
+                        }
+                    });
+
+                    if (event.children_string_values && event.children_string_values.length > 0) {
+                        processChildrenStringValues(
+                            event.children_string_values,
+                            categoryMap,
+                            valueLabels,
+                            prettifyNames,
+                            event.time || Date.now(),
+                            valueColumnIndex,
+                        );
+                    }
+                }
+
+                const newestData = Array.from(categoryMap.values());
+                const latestTicks = new Map<string, number>();
+
+                newestData.forEach(dataPoint => {
+                    const currentTick = latestTicks.get(dataPoint.category) ?? 0;
+                    if (dataPoint.time > currentTick) {
+                        latestTicks.set(dataPoint.category, dataPoint.time);
+                    }
+                });
+
+                const filteredData = newestData.filter(dataPoint => {
+                    const latestTick = latestTicks.get(dataPoint.category);
+                    return latestTick !== undefined && latestTick === dataPoint.time;
+                });
+
+                filteredData.sort((left, right) => {
+                    const compareValue = compareRows(
+                        left,
+                        right,
+                        selectedSortType,
+                        selectedSortColumn,
+                        valueLabels.length,
+                    );
+
+                    return selectedSortOrder === MinecraftGroupedStatisticTableSortOrder.Ascending
+                        ? compareValue
+                        : -compareValue;
+                });
+
+                return filteredData;
+            });
+        };
+
+        statisticDataProvider.registerWindowListener(window);
+        statisticDataProvider.addSubscriber(eventHandler);
+
+        return () => {
+            statisticDataProvider.removeSubscriber(eventHandler);
+            statisticDataProvider.unregisterWindowListener(window);
+        };
+    }, [
+        nonConsolidatedColumnResolver,
+        prettifyNames,
+        selectedSortColumn,
+        selectedSortOrder,
+        selectedSortType,
+        statisticDataProvider,
+        statisticResolver,
+        valueLabels,
+    ]);
+
+    const groupedData = useMemo((): GroupedStatisticTableGroup[] => {
+        if (!isGroupedMode) {
+            return [];
+        }
+
+        const groups = new Map<string, GroupedStatisticTableGroup>();
+
+        data.forEach(dataPoint => {
+            const groupKey = groupKeyResolver(dataPoint.category);
+            const existingGroup = groups.get(groupKey);
+
+            if (!existingGroup) {
+                groups.set(groupKey, {
+                    key: groupKey,
+                    rows: [dataPoint],
+                    count: 1,
+                    sums: Array(valueLabels.length).fill(0),
+                    averages: Array(valueLabels.length).fill(0),
+                });
+                return;
+            }
+
+            existingGroup.rows.push(dataPoint);
+            existingGroup.count += 1;
+        });
+
+        const groupedRows = Array.from(groups.values()).map(group => {
+            const sums = Array(valueLabels.length).fill(0);
+
+            group.rows.forEach(row => {
+                for (let index = 0; index < valueLabels.length; index += 1) {
+                    const numericValue = getNumericValue(row.values[index] ?? 0);
+                    if (numericValue !== undefined) {
+                        sums[index] += numericValue;
+                    }
+                }
+            });
+
+            const averages = sums.map(sum => (group.count === 0 ? 0 : sum / group.count));
+            const sortedRows = [...group.rows].sort((left, right) => {
+                const compareValue = compareRows(left, right, selectedSortType, selectedSortColumn, valueLabels.length);
+
+                return selectedSortOrder === MinecraftGroupedStatisticTableSortOrder.Ascending
+                    ? compareValue
+                    : -compareValue;
+            });
+
+            return {
+                ...group,
+                rows: sortedRows,
+                sums,
+                averages,
+            };
+        });
+
+        groupedRows.sort((left, right) => {
+            let compareValue = left.key.localeCompare(right.key);
+
+            if (selectedSortColumn !== MinecraftGroupedStatisticTableSortColumn.Key) {
+                const columnIndex = getColumnIndexFromSortColumn(selectedSortColumn, valueLabels.length);
+                if (columnIndex !== undefined) {
+                    const leftAggregatedValue = getAggregatedGroupColumnValue(
+                        left,
+                        columnIndex,
+                        groupColumnAggregations,
+                    );
+                    const rightAggregatedValue = getAggregatedGroupColumnValue(
+                        right,
+                        columnIndex,
+                        groupColumnAggregations,
+                    );
+
+                    if (selectedSortType === MinecraftGroupedStatisticTableSortType.Numerical) {
+                        compareValue = leftAggregatedValue - rightAggregatedValue;
+                    } else {
+                        compareValue = String(leftAggregatedValue).localeCompare(String(rightAggregatedValue));
+                    }
+                }
+            }
+
+            return selectedSortOrder === MinecraftGroupedStatisticTableSortOrder.Ascending
+                ? compareValue
+                : -compareValue;
+        });
+
+        return groupedRows;
+    }, [
+        data,
+        groupColumnAggregations,
+        groupKeyResolver,
+        isGroupedMode,
+        selectedSortColumn,
+        selectedSortOrder,
+        selectedSortType,
+        valueLabels,
+    ]);
+
+    useEffect(() => {
+        if (!isGroupedMode) {
+            setExpandedGroups(new Set());
+            return;
+        }
+
+        setExpandedGroups(previousExpandedGroups => {
+            const updated = new Set<string>();
+
+            groupedData.forEach(group => {
+                if (previousExpandedGroups.has(group.key) || !defaultCollapsed) {
+                    updated.add(group.key);
+                }
+            });
+
+            return updated;
+        });
+    }, [defaultCollapsed, groupedData, isGroupedMode]);
+
+    const renderLeafRow = (row: GroupedStatisticTableRow, rowKey: string): JSX.Element => (
+        <tr key={rowKey} className="minecraft-grouped-statistic-child-row">
+            <td>
+                <span className="minecraft-grouped-statistic-child-key">{row.category}</span>
+            </td>
+            {row.values.map((value, valueIndex) => (
+                <td key={valueIndex} className="minecraft-grouped-statistic-table-grid-numeric">
+                    {valueFormatter
+                        ? valueFormatter(value, valueIndex)
+                        : typeof value === 'number'
+                          ? value.toFixed(1)
+                          : value}
+                </td>
+            ))}
+            {rowAction && (
+                <td
+                    className="minecraft-grouped-statistic-table-grid-action"
+                    style={{ width: rowAction.width || '120px' }}
+                >
+                    <VSCodeButton onClick={() => rowAction.onClick(row)} disabled={rowAction.disabled?.(row) ?? false}>
+                        {rowAction.label}
+                    </VSCodeButton>
+                </td>
+            )}
+        </tr>
+    );
+
+    return (
+        <div className="minecraft-grouped-statistic-table-root">
+            {showTitle && <h2>{title}</h2>}
+            <div className="minecraft-grouped-statistic-toolbar">
+                <div className="minecraft-grouped-statistic-toolbar-group">
+                    <label htmlFor={`${controlIdBase}-sort-order`}>Sort Order</label>
+                    <VSCodeDropdown
+                        id={`${controlIdBase}-sort-order`}
+                        onChange={onSelectedSortOrderChange}
+                        value={`${selectedSortOrder}`}
+                    >
+                        {sortOrderOptions.map(option => (
+                            <VSCodeOption key={option.id} value={`${option.id}`}>
+                                {option.label}
+                            </VSCodeOption>
+                        ))}
+                    </VSCodeDropdown>
+                </div>
+                <div className="minecraft-grouped-statistic-toolbar-group">
+                    <label htmlFor={`${controlIdBase}-sort-type`}>Sort Type</label>
+                    <VSCodeDropdown
+                        id={`${controlIdBase}-sort-type`}
+                        onChange={onSelectedSortTypeChange}
+                        value={`${selectedSortType}`}
+                    >
+                        {sortTypeOptions.map(option => (
+                            <VSCodeOption key={option.id} value={`${option.id}`}>
+                                {option.label}
+                            </VSCodeOption>
+                        ))}
+                    </VSCodeDropdown>
+                </div>
+                <div className="minecraft-grouped-statistic-toolbar-group">
+                    <label htmlFor={`${controlIdBase}-sort-column`}>Sort Column</label>
+                    <VSCodeDropdown
+                        id={`${controlIdBase}-sort-column`}
+                        onChange={onSelectedSortColumnChange}
+                        value={selectedSortColumn}
+                    >
+                        {sortColumnOptions.map(option => (
+                            <VSCodeOption key={option.id} value={option.id}>
+                                {option.label}
+                            </VSCodeOption>
+                        ))}
+                    </VSCodeDropdown>
+                </div>
+            </div>
+
+            <div className="minecraft-grouped-statistic-table-surface">
+                <table className="minecraft-grouped-statistic-table-grid">
+                    <thead>
+                        <tr>
+                            <th>{keyLabel}</th>
+                            {valueLabels.map(label => (
+                                <th key={label} className="minecraft-grouped-statistic-table-grid-numeric">
+                                    {label}
+                                </th>
+                            ))}
+                            {rowAction && (
+                                <th className="minecraft-grouped-statistic-table-grid-action">
+                                    {rowAction.headerLabel || 'Action'}
+                                </th>
+                            )}
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {isGroupedMode
+                            ? groupedData.flatMap((group, groupIndex) => {
+                                  const isExpanded = expandedGroups.has(group.key);
+                                  const rows: JSX.Element[] = [
+                                      <tr
+                                          key={`group-${group.key}-${groupIndex}`}
+                                          className="minecraft-grouped-statistic-group-row"
+                                      >
+                                          <td>
+                                              <button
+                                                  type="button"
+                                                  className="minecraft-grouped-statistic-toggle"
+                                                  onClick={() => onToggleGroup(group.key)}
+                                                  aria-expanded={isExpanded}
+                                                  aria-label={isExpanded ? 'Collapse group' : 'Expand group'}
+                                              >
+                                                  {isExpanded ? '▾' : '▸'}
+                                              </button>
+                                              <span className="minecraft-grouped-statistic-group-key">{group.key}</span>
+                                              <span className="minecraft-grouped-statistic-group-meta">
+                                                  ({group.count} {groupCountLabel})
+                                              </span>
+                                          </td>
+                                          {valueLabels.map((label, valueIndex) => {
+                                              const aggregatedValue = getAggregatedGroupColumnValue(
+                                                  group,
+                                                  valueIndex,
+                                                  groupColumnAggregations,
+                                              );
+                                              const aggregation = getGroupColumnAggregation(
+                                                  valueIndex,
+                                                  groupColumnAggregations,
+                                              );
+                                              const formattedValue = valueFormatter
+                                                  ? valueFormatter(aggregatedValue, valueIndex)
+                                                  : aggregatedValue.toFixed(1);
+                                              const displayValue =
+                                                  aggregation ===
+                                                  MinecraftGroupedStatisticTableColumnAggregation.Average
+                                                      ? `${formattedValue} (avg)`
+                                                      : formattedValue;
+
+                                              return (
+                                                  <td
+                                                      key={`${group.key}-${label}`}
+                                                      className="minecraft-grouped-statistic-table-grid-numeric"
+                                                  >
+                                                      {displayValue}
+                                                  </td>
+                                              );
+                                          })}
+                                          {rowAction && (
+                                              <td className="minecraft-grouped-statistic-table-grid-action" />
+                                          )}
+                                      </tr>,
+                                  ];
+
+                                  if (!isExpanded) {
+                                      return rows;
+                                  }
+
+                                  return [
+                                      ...rows,
+                                      ...group.rows.map((row, rowIndex) =>
+                                          renderLeafRow(
+                                              row,
+                                              `group-${group.key}-${groupIndex}-row-${row.category}-${rowIndex}`,
+                                          ),
+                                      ),
+                                  ];
+                              })
+                            : data.map((row, rowIndex) => renderLeafRow(row, `flat-row-${row.category}-${rowIndex}`))}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    );
+}

--- a/webview-ui/src/diagnostics_panel/controls/MinecraftGroupedStatisticTable.tsx
+++ b/webview-ui/src/diagnostics_panel/controls/MinecraftGroupedStatisticTable.tsx
@@ -1,3 +1,5 @@
+// Copyright (C) Microsoft Corporation.  All rights reserved.
+
 import { useCallback, useEffect, useId, useMemo, useState } from 'react';
 import { MultipleStatisticProvider, StatisticUpdatedMessage } from '../StatisticProvider';
 import { StatisticResolver } from '../StatisticResolver';

--- a/webview-ui/src/diagnostics_panel/controls/MinecraftGroupedStatisticTable.tsx
+++ b/webview-ui/src/diagnostics_panel/controls/MinecraftGroupedStatisticTable.tsx
@@ -170,9 +170,11 @@ function processChildrenStringValues(
     valueLabels: string[],
     prettifyNames: boolean,
     eventTime: number,
-    targetColumnIndex?: number,
 ): void {
     childrenStringValues.forEach(childRow => {
+        // The first childRow value is the rowName,
+        // followed by values,
+        // only process rows that have at least a value
         if (childRow.length < 2) {
             return;
         }
@@ -197,20 +199,6 @@ function processChildrenStringValues(
                   ?.replace(/([a-z])([A-Z])/g, '$1 $2')
                   ?.replace(/^./, (character: string) => character.toUpperCase()) || rowName
             : rowName.split('::').pop() || rowName;
-
-        if (targetColumnIndex !== undefined && values.length === 1 && valueLabels.length > 1) {
-            const existingValues = categoryMap.get(cleanRowName)?.values ?? Array(valueLabels.length).fill('');
-            const mergedValues = [...existingValues];
-            mergedValues[targetColumnIndex] = values[0];
-
-            categoryMap.set(cleanRowName, {
-                category: cleanRowName,
-                values: mergedValues,
-                time: eventTime,
-            });
-
-            return;
-        }
 
         categoryMap.set(cleanRowName, {
             category: cleanRowName,
@@ -343,7 +331,6 @@ export default function MinecraftGroupedStatisticTable({
                         valueLabels,
                         prettifyNames,
                         event.time || Date.now(),
-                        valueColumnIndex,
                     );
                 } else {
                     const rawStats = statisticResolver(event, []);
@@ -382,7 +369,6 @@ export default function MinecraftGroupedStatisticTable({
                             valueLabels,
                             prettifyNames,
                             event.time || Date.now(),
-                            valueColumnIndex,
                         );
                     }
                 }

--- a/webview-ui/src/diagnostics_panel/prefabs/tabs/ClientEntitySystems.tsx
+++ b/webview-ui/src/diagnostics_panel/prefabs/tabs/ClientEntitySystems.tsx
@@ -1,10 +1,12 @@
 import { MultipleStatisticProvider } from '../../StatisticProvider';
 import { ParentNameStatResolver, StatisticType, YAxisType, createStatResolver } from '../../StatisticResolver';
 import { TabPrefab, TabPrefabDataSource, TabPrefabParams } from '../TabPrefab';
-import MinecraftMultiColumnStatisticTable, {
-    MinecraftMultiColumnStatisticTableSortOrder,
-    MinecraftMultiColumnStatisticTableSortType,
-} from '../../controls/MinecraftMultiColumnStatisticTable';
+import MinecraftGroupedStatisticTable, {
+    MinecraftGroupedStatisticTableColumnAggregation,
+    MinecraftGroupedStatisticTableDisplayMode,
+    MinecraftGroupedStatisticTableSortOrder,
+    MinecraftGroupedStatisticTableSortType,
+} from '../../controls/MinecraftGroupedStatisticTable';
 import {
     DebuggerRequestResultMessage,
     getDebuggerRequestResult,
@@ -24,9 +26,10 @@ const DEBUGGER_REQUEST_COMMANDS = [
 ];
 
 type TimingUnit = 'ns' | 'us' | 'ms';
+type EntityViewMode = 'flat' | 'grouped';
 
-function ceilToThreeDecimalPlaces(value: number): number {
-    return Math.ceil(value * 1000) / 1000;
+function ceilToDecimalPlace(value: number, decimalPlaces: number): string {
+    return (Math.ceil(value * Math.pow(10, decimalPlaces)) / Math.pow(10, decimalPlaces)).toFixed(decimalPlaces);
 }
 
 function getTimingColumnLabel(unit: TimingUnit): string {
@@ -41,22 +44,28 @@ function getTimingColumnLabel(unit: TimingUnit): string {
     return 'Time In Nanoseconds';
 }
 
-function formatTimingValue(value: string | number, unit: TimingUnit): string {
-    const numericValue = typeof value === 'number' ? value : Number(value);
-
-    if (!Number.isFinite(numericValue)) {
-        return unit === 'ns' ? '0' : '0.000';
+function formatTimingValue(value: number, unit: TimingUnit): string {
+    if (!Number.isFinite(value)) {
+        return `0 ${unit}`;
     }
 
     if (unit === 'ms') {
-        return ceilToThreeDecimalPlaces(numericValue / 1_000_000).toFixed(3);
+        return `${ceilToDecimalPlace(value / 1_000_000, 3)} ms`;
     }
 
     if (unit === 'us') {
-        return ceilToThreeDecimalPlaces(numericValue / 1_000).toFixed(3);
+        return `${ceilToDecimalPlace(value / 1_000, 1)} us`;
     }
 
-    return `${Math.ceil(numericValue)}`;
+    return `${value} ns`;
+}
+
+function formatPercentageValue(value: number): string {
+    if (!Number.isFinite(value)) {
+        return '0 %';
+    }
+
+    return `${ceilToDecimalPlace(value, 0)} %`;
 }
 
 function resolveEcsColumn(eventId: string): number | undefined {
@@ -68,6 +77,20 @@ function resolveEcsColumn(eventId: string): number | undefined {
         default:
             return undefined;
     }
+}
+
+function resolveEntityTypeGroupKey(fullName: string): string {
+    // Example fullName: "minecraft:entity_name<> (2:12345)"
+    // First remove anything after the first '<'
+    let groupName = fullName ? fullName.split('<')[0] : 'NULL';
+    // Then account for the case we don't have the '<>' and remove anything after the first '('
+    groupName = groupName ? groupName.split('(')[0] : 'NULL';
+    return groupName;
+}
+
+function extractEntityId(entityCategory: string): string | undefined {
+    const match = entityCategory.match(/[#:](\d+)\)\s*$/);
+    return match?.[1];
 }
 
 function lastResultToUserFriendlyString(lastResult: DebuggerRequestResultMessage): string {
@@ -93,6 +116,9 @@ const statsTab: TabPrefab = {
         const [clearResetEpoch, setClearResetEpoch] = useState(0);
         const [entityTimingUnit, setEntityTimingUnit] = useState<TimingUnit>('ms');
         const [systemTimingUnit, setSystemTimingUnit] = useState<TimingUnit>('us');
+        const [entityViewMode, setEntityViewMode] = useState<EntityViewMode>('grouped');
+
+        const entityValueLabels = [getTimingColumnLabel(entityTimingUnit), 'Percent Of Total'];
 
         const lastResult: DebuggerRequestResultMessage | undefined = lastRequestedCommand
             ? getDebuggerRequestResult(lastRequestedCommand)
@@ -132,36 +158,68 @@ const statsTab: TabPrefab = {
                         </div>
                     </div>
                 </div>
-                <div style={{ flexDirection: 'row', display: 'flex', width: '75%' }}>
+                <div style={{ flexDirection: 'row', display: 'flex', width: '90%' }}>
                     <div style={{ flex: 1, marginRight: '5px' }}>
-                        <div
-                            style={{
-                                marginTop: '10px',
-                                marginBottom: '10px',
-                                width: `150px`,
-                            }}
-                        >
-                            <label htmlFor="ecs-entity-timing-unit" style={{ marginBottom: '5px' }}>
-                                Entity Timing Unit
-                            </label>
-                            <VSCodeDropdown
-                                id="ecs-entity-timing-unit"
-                                value={entityTimingUnit}
-                                onChange={(event: Event | React.FormEvent<HTMLElement>) => {
-                                    const target = event.target as HTMLSelectElement;
-                                    setEntityTimingUnit(target.value as TimingUnit);
-                                }}
-                            >
-                                <VSCodeOption value="ns">Nanoseconds</VSCodeOption>
-                                <VSCodeOption value="us">Microseconds</VSCodeOption>
-                                <VSCodeOption value="ms">Milliseconds</VSCodeOption>
-                            </VSCodeDropdown>
+                        <div style={{ marginTop: '10px', marginBottom: '10px' }}>
+                            <h2>Entity Timings</h2>
+                            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '10px' }}>
+                                <div className="dropdown-container">
+                                    <label htmlFor="ecs-entity-timing-unit" style={{ marginBottom: '5px' }}>
+                                        Entity Timing Unit
+                                    </label>
+                                    <VSCodeDropdown
+                                        id="ecs-entity-timing-unit"
+                                        value={entityTimingUnit}
+                                        onChange={(event: Event | React.FormEvent<HTMLElement>) => {
+                                            const target = event.target as HTMLSelectElement;
+                                            setEntityTimingUnit(target.value as TimingUnit);
+                                        }}
+                                    >
+                                        <VSCodeOption value="ns">Nanoseconds</VSCodeOption>
+                                        <VSCodeOption value="us">Microseconds</VSCodeOption>
+                                        <VSCodeOption value="ms">Milliseconds</VSCodeOption>
+                                    </VSCodeDropdown>
+                                </div>
+                                <div className="dropdown-container">
+                                    <label htmlFor="ecs-entity-view-mode" style={{ marginBottom: '5px' }}>
+                                        Entity View
+                                    </label>
+                                    <VSCodeDropdown
+                                        id="ecs-entity-view-mode"
+                                        value={entityViewMode}
+                                        onChange={(event: Event | React.FormEvent<HTMLElement>) => {
+                                            const target = event.target as HTMLSelectElement;
+                                            setEntityViewMode(target.value as EntityViewMode);
+                                        }}
+                                    >
+                                        <VSCodeOption value="grouped">Grouped</VSCodeOption>
+                                        <VSCodeOption value="flat">Flat</VSCodeOption>
+                                    </VSCodeDropdown>
+                                </div>
+                            </div>
                         </div>
-                        <MinecraftMultiColumnStatisticTable
-                            key={`entity-timings-${selectedClient}-${clearResetEpoch}`}
+
+                        <MinecraftGroupedStatisticTable
+                            key={`entity-timings-${entityViewMode}-${selectedClient}-${clearResetEpoch}`}
                             title="Entity Timings"
+                            showTitle={false}
                             keyLabel="Entity"
-                            valueLabels={[getTimingColumnLabel(entityTimingUnit), 'Percent Of Total']}
+                            valueLabels={entityValueLabels}
+                            displayMode={
+                                entityViewMode === 'grouped'
+                                    ? MinecraftGroupedStatisticTableDisplayMode.Grouped
+                                    : MinecraftGroupedStatisticTableDisplayMode.Flat
+                            }
+                            groupColumnAggregations={[
+                                MinecraftGroupedStatisticTableColumnAggregation.Average,
+                                MinecraftGroupedStatisticTableColumnAggregation.Sum,
+                            ]}
+                            getGroupKey={resolveEntityTypeGroupKey}
+                            groupCountLabel="entities"
+                            defaultCollapsed={true}
+                            defaultSortColumn="value_1"
+                            defaultSortOrder={MinecraftGroupedStatisticTableSortOrder.Descending}
+                            defaultSortType={MinecraftGroupedStatisticTableSortType.Numerical}
                             statisticDataProvider={
                                 new MultipleStatisticProvider({
                                     statisticIds: ['time_in_ns', 'percent_of_total'],
@@ -176,27 +234,24 @@ const statsTab: TabPrefab = {
                                     valueScalar: 1,
                                 }),
                             )}
-                            defaultSortColumn="value_1"
-                            defaultSortOrder={MinecraftMultiColumnStatisticTableSortOrder.Descending}
-                            defaultSortType={MinecraftMultiColumnStatisticTableSortType.Numerical}
-                            columnWidths={['auto', 'auto', 'auto', '70px']}
-                            prettifyNames={false}
                             rowAction={{
                                 label: '🔍',
                                 headerLabel: 'Focus',
                                 width: '70px',
                                 disabled: () => isDebuggerRequestInFlight(START_ENTITY_SYSTEM_PROFILER_REQUEST),
                                 onClick: async row => {
+                                    const entityId = extractEntityId(row.category);
+                                    if (!entityId) {
+                                        return;
+                                    }
+
                                     setLastRequestedCommand(START_ENTITY_SYSTEM_PROFILER_REQUEST);
 
-                                    // given an entity name like: minecraft:arrow<> (2#262231)
-                                    // we want to extract the numeric id at the end (262231 in this case) to send to the profiler
                                     const args = {
-                                        entityId: row.category.split('#')[1]?.replace(')', ''),
+                                        entityId,
                                     };
                                     sendDebuggerRequest(START_ENTITY_SYSTEM_PROFILER_REQUEST, args);
 
-                                    // Wait for isDebuggerRequestInFlight to become false and then clear
                                     while (isDebuggerRequestInFlight(START_ENTITY_SYSTEM_PROFILER_REQUEST)) {
                                         await new Promise(resolve => setTimeout(resolve, 100));
                                     }
@@ -205,43 +260,53 @@ const statsTab: TabPrefab = {
                             }}
                             nonConsolidatedColumnResolver={event => resolveEcsColumn(event.id)}
                             valueFormatter={(value, columnIndex) => {
+                                // Timing column
                                 if (columnIndex === 0) {
-                                    return formatTimingValue(value, entityTimingUnit);
+                                    return formatTimingValue(Number(value), entityTimingUnit);
+                                }
+                                // Percentage column
+                                else if (columnIndex === 1) {
+                                    return formatPercentageValue(Number(value));
                                 }
 
-                                return typeof value === 'number' ? value.toFixed(1) : String(value);
+                                return String(value);
                             }}
                         />
                     </div>
                     <div style={{ flex: 1, marginRight: '5px' }}>
-                        <div
-                            style={{
-                                marginTop: '10px',
-                                marginBottom: '10px',
-                                width: `150px`,
-                            }}
-                        >
-                            <label htmlFor="ecs-system-timing-unit" style={{ marginBottom: '5px' }}>
-                                System Timing Unit
-                            </label>
-                            <VSCodeDropdown
-                                id="ecs-system-timing-unit"
-                                value={systemTimingUnit}
-                                onChange={(event: Event | React.FormEvent<HTMLElement>) => {
-                                    const target = event.target as HTMLSelectElement;
-                                    setSystemTimingUnit(target.value as TimingUnit);
-                                }}
-                            >
-                                <VSCodeOption value="ns">Nanoseconds</VSCodeOption>
-                                <VSCodeOption value="us">Microseconds</VSCodeOption>
-                                <VSCodeOption value="ms">Milliseconds</VSCodeOption>
-                            </VSCodeDropdown>
+                        <div style={{ marginTop: '10px', marginBottom: '10px' }}>
+                            <h2>System Timings</h2>
+                            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '10px' }}>
+                                <div className="dropdown-container">
+                                    <label htmlFor="ecs-system-timing-unit" style={{ marginBottom: '5px' }}>
+                                        System Timing Unit
+                                    </label>
+                                    <VSCodeDropdown
+                                        id="ecs-system-timing-unit"
+                                        value={systemTimingUnit}
+                                        onChange={(event: Event | React.FormEvent<HTMLElement>) => {
+                                            const target = event.target as HTMLSelectElement;
+                                            setSystemTimingUnit(target.value as TimingUnit);
+                                        }}
+                                    >
+                                        <VSCodeOption value="ns">Nanoseconds</VSCodeOption>
+                                        <VSCodeOption value="us">Microseconds</VSCodeOption>
+                                        <VSCodeOption value="ms">Milliseconds</VSCodeOption>
+                                    </VSCodeDropdown>
+                                </div>
+                            </div>
                         </div>
-                        <MinecraftMultiColumnStatisticTable
+                        <MinecraftGroupedStatisticTable
                             key={`system-timings-${selectedClient}-${clearResetEpoch}`}
                             title="System Timings"
+                            showTitle={false}
                             keyLabel="System"
                             valueLabels={[getTimingColumnLabel(systemTimingUnit), 'Percent Of Total']}
+                            displayMode={MinecraftGroupedStatisticTableDisplayMode.Flat}
+                            groupColumnAggregations={[
+                                MinecraftGroupedStatisticTableColumnAggregation.Average,
+                                MinecraftGroupedStatisticTableColumnAggregation.Sum,
+                            ]}
                             statisticDataProvider={
                                 new MultipleStatisticProvider({
                                     statisticIds: ['time_in_ns', 'percent_of_total'],
@@ -257,17 +322,21 @@ const statsTab: TabPrefab = {
                                 }),
                             )}
                             defaultSortColumn="value_1"
-                            defaultSortOrder={MinecraftMultiColumnStatisticTableSortOrder.Descending}
-                            defaultSortType={MinecraftMultiColumnStatisticTableSortType.Numerical}
-                            columnWidths={['auto', 'auto', 'auto']}
+                            defaultSortOrder={MinecraftGroupedStatisticTableSortOrder.Descending}
+                            defaultSortType={MinecraftGroupedStatisticTableSortType.Numerical}
                             prettifyNames={false}
                             nonConsolidatedColumnResolver={event => resolveEcsColumn(event.id)}
                             valueFormatter={(value, columnIndex) => {
+                                // Timing column
                                 if (columnIndex === 0) {
-                                    return formatTimingValue(value, systemTimingUnit);
+                                    return formatTimingValue(Number(value), systemTimingUnit);
+                                }
+                                // Percentage column
+                                else if (columnIndex === 1) {
+                                    return formatPercentageValue(Number(value));
                                 }
 
-                                return typeof value === 'number' ? value.toFixed(1) : String(value);
+                                return String(value);
                             }}
                         />
                     </div>


### PR DESCRIPTION
This change moves the `Client - Entity Systems` view away from the MultiColumnStatisticTable and into a new `MinecraftGroupedStatisticTable`. 

While much of the logic is ported over from the MultiColumn table the key changes are to support grouping statistics under shared parents. The parent rows are then able to aggregate the data for display at the group level. Each group has a dropdown allowing you to explore the children view as well.

The table supports a flat mode as well that doesn't utilize grouping but allows for utilizing the same visuals. 

Currently the Entity's are grouped by name, System grouping will come in a follow up change utilizing system categories for the groups.


https://github.com/user-attachments/assets/f2746b4b-39fe-4074-97b8-b5fb8643f16a

