### PR TITLE
feat: Changing diagnostics tabs to be a vertical list, some other UI improvements

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -845,7 +845,7 @@ export class Session extends DebugSession implements IDebuggeeMessageSender {
             this._terminated = true;
 
             this.sendEvent(new TerminatedEvent());
-            this.showNotification(`Session terminated, ${reason}.`, logLevel);
+            this.showNotification(`Session terminated, ${reason}.`, logLevel, logLevel !== LogLevel.Log);
             this._homeViewProvider.setDebuggerStatus(false, this._minecraftCapabilities);
             this.dispose();
         }

--- a/webview-ui/src/diagnostics_panel/App.css
+++ b/webview-ui/src/diagnostics_panel/App.css
@@ -1,9 +1,58 @@
 main {
   display: flex;
   flex-direction: column;
-  justify-content: center;
   align-items: flex-start;
   height: 100%;
+  overflow: hidden;
+}
+
+.vertical-tabs-container {
+  display: flex;
+  flex-direction: row;
+  flex: 1;
+  overflow: hidden;
+  width: 100%;
+}
+
+.vertical-tab-list {
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  min-width: 160px;
+  flex-shrink: 0;
+  border-right: 1px solid var(--vscode-editorGroup-border);
+}
+
+.vertical-tab-item {
+  background: transparent;
+  border: none;
+  color: var(--vscode-foreground);
+  font-size: var(--vscode-font-size);
+  font-family: var(--vscode-font-family);
+  text-align: left;
+  padding: 8px 12px;
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.vertical-tab-item:hover {
+  background-color: var(--vscode-list-hoverBackground);
+  color: var(--vscode-list-hoverForeground);
+}
+
+.vertical-tab-item.active {
+  background-color: var(--vscode-list-activeSelectionBackground);
+  color: var(--vscode-list-activeSelectionForeground);
+}
+
+.vertical-tab-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0 12px;
+  display: flex;
+  flex-direction: column;
 }
 
 .dropdown-container {

--- a/webview-ui/src/diagnostics_panel/App.tsx
+++ b/webview-ui/src/diagnostics_panel/App.tsx
@@ -1,24 +1,26 @@
 // Copyright (C) Microsoft Corporation.  All rights reserved.
 
-import { VSCodePanelTab, VSCodePanelView, VSCodePanels } from '@vscode/webview-ui-toolkit/react';
 import { StatGroupSelectionBox } from './controls/StatGroupSelectionBox';
 import { useCallback, useEffect, useState } from 'react';
 import ReplayControls from './controls/ReplayControls';
 import { Icons } from './Icons';
 import './App.css';
 import tabPrefabs from './prefabs';
-import { TabPrefabDataSource } from './prefabs/TabPrefab';
+import { TabPrefab, TabPrefabDataSource, TabPrefabParams } from './prefabs/TabPrefab';
 import { handleDebuggerRequestResult } from './utilities/useDebuggerRequests';
 import { vscode } from './utilities/vscode';
+
+// Wraps each tab's content() as a proper React component so that any hooks
+// inside the content function are correctly isolated and not called conditionally
+// from the parent App component (which would violate the Rules of Hooks).
+function TabView({ tabPrefab, params }: { tabPrefab: TabPrefab; params: TabPrefabParams }) {
+    return <>{tabPrefab.content(params)}</>;
+}
 
 declare global {
     interface Window {
         initialParams: any;
     }
-}
-
-interface VSCodePanelsChangeEvent extends Event {
-    target: EventTarget & { activeid: string };
 }
 
 const onRestart = () => {
@@ -46,9 +48,10 @@ const onRunCommand = (command: string) => {
 };
 
 function App() {
+    const sortedTabPrefabs = [...tabPrefabs].sort((a, b) => a.name.localeCompare(b.name));
     const [selectedPlugin, setSelectedPlugin] = useState<string>('');
     const [selectedClient, setSelectedClient] = useState<string>('');
-    const [currentTab, setCurrentTab] = useState<string>();
+    const [currentTab, setCurrentTab] = useState<string>('tab-0');
     const [paused, setPaused] = useState<boolean>(true);
     const [speed, setSpeed] = useState<string>('');
 
@@ -60,12 +63,7 @@ function App() {
         setSelectedClient(() => clientSelectionId);
     }, []);
 
-    const handlePanelChange = useCallback((event: VSCodePanelsChangeEvent): void => {
-        const newTabId = event.target.activeid;
-        if (newTabId) {
-            setCurrentTab(newTabId);
-        }
-    }, []);
+
 
     useEffect(() => {
         const handleMessage = (event: MessageEvent) => {
@@ -98,38 +96,50 @@ function App() {
                     svgIcons={Icons}
                 />
             )}
-            <VSCodePanels activeid={currentTab} onChange={event => handlePanelChange(event as VSCodePanelsChangeEvent)}>
-                {tabPrefabs.map((tabPrefab, index) => (
-                    <VSCodePanelTab id={`tab-${index}`}>{tabPrefab.name}</VSCodePanelTab>
-                ))}
-                {tabPrefabs.map((tabPrefab, index) => (
-                    <VSCodePanelView id={`view-${index}`} style={{ flexDirection: 'column' }}>
-                        {tabPrefab.dataSource === TabPrefabDataSource.Client ? (
-                            <StatGroupSelectionBox
-                                labelName="Client"
-                                statParentId="client_stats"
-                                onChange={handleClientSelection}
+            <div className="vertical-tabs-container">
+                <div className="vertical-tab-list">
+                    {sortedTabPrefabs.map((tabPrefab, index) => (
+                        <button
+                            key={`tab-${index}`}
+                            className={`vertical-tab-item${currentTab === `tab-${index}` ? ' active' : ''}`}
+                            onClick={() => setCurrentTab(`tab-${index}`)}
+                        >
+                            {tabPrefab.name}
+                        </button>
+                    ))}
+                </div>
+                <div className="vertical-tab-content">
+                    {sortedTabPrefabs.map((tabPrefab, index) => (
+                        <div
+                            key={`view-${index}`}
+                            style={{ display: currentTab === `tab-${index}` ? 'flex' : 'none', flexDirection: 'column', flex: 1 }}
+                        >
+                            {tabPrefab.dataSource === TabPrefabDataSource.Client ? (
+                                <StatGroupSelectionBox
+                                    labelName="Client"
+                                    statParentId="client_stats"
+                                    onChange={handleClientSelection}
+                                />
+                            ) : (
+                                <div />
+                            )}
+                            {tabPrefab.dataSource === TabPrefabDataSource.ServerScript ? (
+                                <StatGroupSelectionBox
+                                    labelName="Script Plugin"
+                                    statParentId="handle_counts"
+                                    onChange={handlePluginSelection}
+                                />
+                            ) : (
+                                <div />
+                            )}
+                            <TabView
+                                tabPrefab={tabPrefab}
+                                params={{ selectedClient, selectedPlugin, onRunCommand }}
                             />
-                        ) : (
-                            <div />
-                        )}
-                        {tabPrefab.dataSource === TabPrefabDataSource.ServerScript ? (
-                            <StatGroupSelectionBox
-                                labelName="Script Plugin"
-                                statParentId="handle_counts"
-                                onChange={handlePluginSelection}
-                            />
-                        ) : (
-                            <div />
-                        )}
-                        {tabPrefab.content({
-                            selectedClient,
-                            selectedPlugin,
-                            onRunCommand,
-                        })}
-                    </VSCodePanelView>
-                ))}
-            </VSCodePanels>
+                        </div>
+                    ))}
+                </div>
+            </div>
         </main>
     );
 }

--- a/webview-ui/src/diagnostics_panel/controls/LineChart/LineChart.tsx
+++ b/webview-ui/src/diagnostics_panel/controls/LineChart/LineChart.tsx
@@ -19,6 +19,15 @@ type LineChartProps = {
 
 type PlotResult = ((SVGSVGElement | HTMLElement) & Plot.Plot) | undefined;
 
+function formatYAxisTick(d: d3.NumberValue): string {
+    const n = d.valueOf();
+    if (n === 0) return '0';
+    const abs = Math.abs(n);
+    if (abs >= 1000) return `${Math.round(n)}`;
+    if (abs >= 1) return `${parseFloat(n.toPrecision(4))}`;
+    return `${parseFloat(n.toPrecision(3))}`;
+}
+
 //chart component
 export function LineChart({
     title,
@@ -94,6 +103,7 @@ export function LineChart({
                     type: yAxisStyle,
                     domain: yDomain,
                     label: yLabel,
+                    tickFormat: formatYAxisTick,
                 },
                 marks: [
                     // TODO: Clean up with factory?
@@ -142,6 +152,7 @@ export function LineChart({
                     type: 'linear',
                     domain: yDomain,
                     label: yLabel,
+                    tickFormat: formatYAxisTick,
                 },
             });
         };


### PR DESCRIPTION
Old horizontal list:
<img width="1852" height="206" alt="image" src="https://github.com/user-attachments/assets/06cdf580-db89-4c4f-9808-4b9fa3d7703f" />

New diagnostics vertical list (sorted):
<img width="841" height="584" alt="image" src="https://github.com/user-attachments/assets/df0b9251-24d2-42a0-a4f5-8a22a32555be" />

Fixing issue where the Y axis values weren't rounded or truncated so they could have super long labels:
<img width="736" height="431" alt="image" src="https://github.com/user-attachments/assets/31a65d85-80e7-4e05-8d28-8e23c19569d3" />

Fixed:
<img width="476" height="412" alt="image" src="https://github.com/user-attachments/assets/9a58e67d-c43f-43f4-a859-030f8d08b921" />


Fixed an issue where the live diagnostics page would fail to load and turn blank on some tabs if Minecraft wasn't connected (such as ECS profiling & dynamic properties).

Changed it so that failure/termination (such as protocol mismatch), also logs to console instead of just the popup notification (as this could easily be missed).