### PR TITLE
feat: Adjust the widths of the CPU Profiler and Entity Systems tabs

### DIFF
--- a/webview-ui/src/diagnostics_panel/prefabs/tabs/ClientCPUProfiler.tsx
+++ b/webview-ui/src/diagnostics_panel/prefabs/tabs/ClientCPUProfiler.tsx
@@ -56,7 +56,7 @@ const StatsTab: TabPrefab = {
 
         return (
             <div>
-                <div style={{ flexDirection: 'column', display: 'flex', width: '25%' }}>
+                <div style={{ flexDirection: 'column', display: 'flex', width: '100%' }}>
                     <div style={{ flex: 1, margin: '5px' }}>
                         <h2>CPU Profiler Controls</h2>
                         {DEBUGGER_REQUEST_COMMANDS.map(command => {
@@ -84,7 +84,7 @@ const StatsTab: TabPrefab = {
                         </div>
                     </div>
                 </div>
-                <div style={{ flexDirection: 'row', display: 'flex', width: '85%' }}>
+                <div style={{ flexDirection: 'row', display: 'flex', width: '100%' }}>
                     <MinecraftProfilerFlameStreamChart
                         title="Profiler Scopes"
                         statisticDataProvider={statisticDataProvider}

--- a/webview-ui/src/diagnostics_panel/prefabs/tabs/ClientEntitySystems.tsx
+++ b/webview-ui/src/diagnostics_panel/prefabs/tabs/ClientEntitySystems.tsx
@@ -181,7 +181,7 @@ const StatsTab: TabPrefab = {
 
         return (
             <div>
-                <div style={{ flexDirection: 'column', display: 'flex', width: '25%' }}>
+                <div style={{ flexDirection: 'column', display: 'flex', width: '100%' }}>
                     <div style={{ flex: 1, margin: '5px' }}>
                         <h2>Entity System Profiler Controls</h2>
                         {DEBUGGER_REQUEST_COMMANDS.map(command => {
@@ -213,7 +213,7 @@ const StatsTab: TabPrefab = {
                         </div>
                     </div>
                 </div>
-                <div style={{ flexDirection: 'row', display: 'flex', width: '90%' }}>
+                <div style={{ flexDirection: 'row', display: 'flex', width: '100%' }}>
                     <div style={{ flex: 1, marginRight: '5px' }}>
                         <div style={{ marginTop: '10px', marginBottom: '10px' }}>
                             <h2>Entity Timings</h2>


### PR DESCRIPTION
With the recent change to swap to a vertical tab layout the CPU Profiler and the Entity Systems views were feeling tight horizontally.

Specifically I had hardcoded some custom width percentages to force both profilers into view due to the fact that the horizontal tabs were pushing the full canvas width out past the screen edge.

Now with the vertical tabs we can just uses 100% of the view width.


https://github.com/user-attachments/assets/13264a89-7b8d-4e52-8752-201a578fb960

