### PR TITLE
feat: Allow different filtering modes of entities in the Client - Entity Systems tab

### DIFF
--- a/webview-ui/src/diagnostics_panel/App.css
+++ b/webview-ui/src/diagnostics_panel/App.css
@@ -267,6 +267,19 @@ main {
   text-align: right;
 }
 
+.minecraft-entity-system-count-badge {
+  display: flex;
+  align-items: center;
+  height: 57px; /* Forces the Entity and Systems charts to be visually aligned */
+}
+
+.minecraft-entity-system-count-badge-content {
+  font-style: italic;
+  padding: 5px;
+  border-radius: 5px;
+  background: color-mix(in srgb, var(--vscode-list-activeSelectionBackground) 33%, var(--vscode-editor-background));
+}
+
 .minecraft-grouped-statistic-table-root {
   width: 100%;
 }
@@ -320,6 +333,12 @@ main {
   width: 90px;
 }
 
+.minecraft-grouped-statistic-table-grid-select {
+  text-align: center !important;
+  width: 72px;
+  padding: 6px 4px !important;
+}
+
 .minecraft-grouped-statistic-table-grid-pin {
   text-align: center !important;
   width: 34px;
@@ -361,6 +380,10 @@ main {
 
 .minecraft-grouped-statistic-row-pinned {
   background: color-mix(in srgb, var(--vscode-list-highlightForeground) 12%, var(--vscode-editor-background));
+}
+
+.minecraft-grouped-statistic-row-selected {
+  box-shadow: inset 3px 0 0 var(--vscode-focusBorder);
 }
 
 .minecraft-profiler-flame-stream-root {

--- a/webview-ui/src/diagnostics_panel/controls/MinecraftGroupedStatisticTable.tsx
+++ b/webview-ui/src/diagnostics_panel/controls/MinecraftGroupedStatisticTable.tsx
@@ -1128,7 +1128,7 @@ const MinecraftGroupedStatisticTable = forwardRef<
                 <table className="minecraft-grouped-statistic-table-grid">
                     <thead>
                         <tr>
-                            <th className="minecraft-grouped-statistic-table-grid-pin" aria-label="Pinned"></th>
+                            <th className="minecraft-grouped-statistic-table-grid-pin">Pin</th>
                             {selectionEnabled && (
                                 <th className="minecraft-grouped-statistic-table-grid-select">
                                     {selectionHeaderLabel}

--- a/webview-ui/src/diagnostics_panel/controls/MinecraftGroupedStatisticTable.tsx
+++ b/webview-ui/src/diagnostics_panel/controls/MinecraftGroupedStatisticTable.tsx
@@ -781,84 +781,40 @@ const MinecraftGroupedStatisticTable = forwardRef<
             validRowKeys.add(getRowPinKey(groupKey, row.category));
         });
 
-        setPinnedGroups(previousPinnedGroups => {
+        const handleUpdateSet = (set: Set<string>, validKeys: Set<string>): Set<string> => {
             let changed = false;
             const updated = new Set<string>();
 
-            previousPinnedGroups.forEach(groupKey => {
-                if (validGroupKeys.has(groupKey)) {
-                    updated.add(groupKey);
+            set.forEach(key => {
+                if (validKeys.has(key)) {
+                    updated.add(key);
                     return;
                 }
 
                 changed = true;
             });
 
-            return changed ? updated : previousPinnedGroups;
+            return changed ? updated : set;
+        };
+
+        setPinnedGroups(previousPinnedGroups => {
+            return handleUpdateSet(previousPinnedGroups, validGroupKeys);
         });
 
         setPinnedRows(previousPinnedRows => {
-            let changed = false;
-            const updated = new Set<string>();
-
-            previousPinnedRows.forEach(rowPinKey => {
-                if (validRowKeys.has(rowPinKey)) {
-                    updated.add(rowPinKey);
-                    return;
-                }
-
-                changed = true;
-            });
-
-            return changed ? updated : previousPinnedRows;
+            return handleUpdateSet(previousPinnedRows, validRowKeys);
         });
 
         setSelectedGroups(previousSelectedGroups => {
-            let changed = false;
-            const updated = new Set<string>();
-
-            previousSelectedGroups.forEach(groupKey => {
-                if (validGroupKeys.has(groupKey)) {
-                    updated.add(groupKey);
-                    return;
-                }
-
-                changed = true;
-            });
-
-            return changed ? updated : previousSelectedGroups;
+            return handleUpdateSet(previousSelectedGroups, validGroupKeys);
         });
 
         setSelectedRows(previousSelectedRows => {
-            let changed = false;
-            const updated = new Set<string>();
-
-            previousSelectedRows.forEach(rowKey => {
-                if (validRowKeys.has(rowKey)) {
-                    updated.add(rowKey);
-                    return;
-                }
-
-                changed = true;
-            });
-
-            return changed ? updated : previousSelectedRows;
+            return handleUpdateSet(previousSelectedRows, validRowKeys);
         });
 
         setDeselectedRowsInSelectedGroups(previousDeselectedRows => {
-            let changed = false;
-            const updated = new Set<string>();
-
-            previousDeselectedRows.forEach(rowKey => {
-                if (validRowKeys.has(rowKey)) {
-                    updated.add(rowKey);
-                    return;
-                }
-
-                changed = true;
-            });
-
-            return changed ? updated : previousDeselectedRows;
+            return handleUpdateSet(previousDeselectedRows, validRowKeys);
         });
     }, [data, groupKeyResolver]);
 

--- a/webview-ui/src/diagnostics_panel/controls/MinecraftGroupedStatisticTable.tsx
+++ b/webview-ui/src/diagnostics_panel/controls/MinecraftGroupedStatisticTable.tsx
@@ -1,6 +1,6 @@
 // Copyright (C) Microsoft Corporation.  All rights reserved.
 
-import { useCallback, useEffect, useId, useMemo, useState } from 'react';
+import { forwardRef, useCallback, useEffect, useId, useImperativeHandle, useMemo, useRef, useState } from 'react';
 import { MultipleStatisticProvider, StatisticUpdatedMessage } from '../StatisticProvider';
 import { StatisticResolver } from '../StatisticResolver';
 import { VSCodeButton, VSCodeCheckbox, VSCodeDropdown, VSCodeOption } from '@vscode/webview-ui-toolkit/react';
@@ -29,7 +29,7 @@ export enum MinecraftGroupedStatisticTableColumnAggregation {
     Sum = 'sum',
 }
 
-type GroupedStatisticTableRow = {
+export type GroupedStatisticTableRow = {
     category: string;
     values: (string | number)[];
     time: number;
@@ -56,6 +56,17 @@ type GroupedStatisticTableRowAction = {
 
 type NonConsolidatedColumnResolver = (event: StatisticUpdatedMessage, valueLabels: string[]) => number | undefined;
 
+export type MinecraftGroupedStatisticTableSelectionSnapshot = {
+    selectedGroupKeys: string[];
+    selectedRowKeys: string[];
+    resolvedSelectedRows: GroupedStatisticTableRow[];
+};
+
+export type MinecraftGroupedStatisticTableHandle = {
+    getSelectionSnapshot: () => MinecraftGroupedStatisticTableSelectionSnapshot;
+    clearSelection: () => void;
+};
+
 type MinecraftGroupedStatisticTableProps = {
     title: string;
     showTitle?: boolean;
@@ -75,6 +86,10 @@ type MinecraftGroupedStatisticTableProps = {
     nonConsolidatedColumnResolver?: NonConsolidatedColumnResolver;
     valueFormatter?: (value: string | number, columnIndex: number) => string;
     prettifyNames?: boolean;
+    selectionEnabled?: boolean;
+    selectionHeaderLabel?: string;
+    defaultSelectAllGroups?: boolean;
+    onSelectionChange?: (snapshot: MinecraftGroupedStatisticTableSelectionSnapshot) => void;
 };
 
 const sortOrderOptions = [
@@ -86,6 +101,8 @@ const sortTypeOptions = [
     { id: MinecraftGroupedStatisticTableSortType.Alphabetical, label: 'Alphabetical' },
     { id: MinecraftGroupedStatisticTableSortType.Numerical, label: 'Numerical' },
 ];
+
+const NON_CONSOLIDATED_STALE_TICK_THRESHOLD = 3;
 
 function getColumnIndexFromSortColumn(sortColumn: string, valueLabelsLength: number): number | undefined {
     const columnIndex = parseInt(sortColumn.replace('value_', ''));
@@ -223,6 +240,7 @@ function processChildrenStringValues(
     valueLabels: string[],
     prettifyNames: boolean,
     eventTime: number,
+    observedCategories?: Set<string>,
 ): void {
     childrenStringValues.forEach(childRow => {
         // The first childRow value is the rowName,
@@ -258,29 +276,40 @@ function processChildrenStringValues(
             values,
             time: eventTime,
         });
+        observedCategories?.add(cleanRowName);
     });
 }
 
-export default function MinecraftGroupedStatisticTable({
-    title,
-    showTitle = true,
-    statisticDataProvider,
-    statisticResolver,
-    keyLabel,
-    valueLabels,
-    getGroupKey,
-    displayMode = MinecraftGroupedStatisticTableDisplayMode.Grouped,
-    groupColumnAggregations = [],
-    groupCountLabel = '',
-    defaultCollapsed = true,
-    defaultSortOrder = MinecraftGroupedStatisticTableSortOrder.Descending,
-    defaultSortType = MinecraftGroupedStatisticTableSortType.Numerical,
-    defaultSortColumn,
-    rowAction,
-    nonConsolidatedColumnResolver,
-    valueFormatter,
-    prettifyNames = false,
-}: MinecraftGroupedStatisticTableProps): JSX.Element {
+const MinecraftGroupedStatisticTable = forwardRef<
+    MinecraftGroupedStatisticTableHandle,
+    MinecraftGroupedStatisticTableProps
+>(function MinecraftGroupedStatisticTable(
+    {
+        title,
+        showTitle = true,
+        statisticDataProvider,
+        statisticResolver,
+        keyLabel,
+        valueLabels,
+        getGroupKey,
+        displayMode = MinecraftGroupedStatisticTableDisplayMode.Grouped,
+        groupColumnAggregations = [],
+        groupCountLabel = '',
+        defaultCollapsed = true,
+        defaultSortOrder = MinecraftGroupedStatisticTableSortOrder.Descending,
+        defaultSortType = MinecraftGroupedStatisticTableSortType.Numerical,
+        defaultSortColumn,
+        rowAction,
+        nonConsolidatedColumnResolver,
+        valueFormatter,
+        prettifyNames = false,
+        selectionEnabled = false,
+        selectionHeaderLabel = 'Selected',
+        defaultSelectAllGroups = false,
+        onSelectionChange,
+    }: MinecraftGroupedStatisticTableProps,
+    ref,
+): JSX.Element {
     const sortColumnOptions = useMemo(
         () => [
             { id: MinecraftGroupedStatisticTableSortColumn.Key, label: keyLabel },
@@ -299,8 +328,81 @@ export default function MinecraftGroupedStatisticTable({
     const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
     const [pinnedGroups, setPinnedGroups] = useState<Set<string>>(new Set());
     const [pinnedRows, setPinnedRows] = useState<Set<string>>(new Set());
+    const [selectedGroups, setSelectedGroups] = useState<Set<string>>(new Set());
+    const [selectedRows, setSelectedRows] = useState<Set<string>>(new Set());
+    const [deselectedRowsInSelectedGroups, setDeselectedRowsInSelectedGroups] = useState<Set<string>>(new Set());
+    const [hasInitializedDefaultSelection, setHasInitializedDefaultSelection] = useState<boolean>(false);
+    const nonConsolidatedTickCounterRef = useRef(0);
+    const nonConsolidatedLastEventTimeRef = useRef<number | undefined>(undefined);
+    const nonConsolidatedLastSeenTickByCategoryRef = useRef<Map<string, number>>(new Map());
     const isGroupedMode = displayMode === MinecraftGroupedStatisticTableDisplayMode.Grouped;
     const groupKeyResolver = getGroupKey ?? ((rowCategory: string) => rowCategory);
+
+    const groupedRowsByKey = useMemo((): Map<string, GroupedStatisticTableRow[]> => {
+        const groupedRows = new Map<string, GroupedStatisticTableRow[]>();
+
+        data.forEach(row => {
+            const groupKey = groupKeyResolver(row.category);
+            const existing = groupedRows.get(groupKey);
+
+            if (existing) {
+                existing.push(row);
+                return;
+            }
+
+            groupedRows.set(groupKey, [row]);
+        });
+
+        return groupedRows;
+    }, [data, groupKeyResolver]);
+
+    const rowKeysByGroup = useMemo((): Map<string, string[]> => {
+        const rowKeys = new Map<string, string[]>();
+
+        groupedRowsByKey.forEach((rows, groupKey) => {
+            rowKeys.set(
+                groupKey,
+                rows.map(row => getRowPinKey(groupKey, row.category)),
+            );
+        });
+
+        return rowKeys;
+    }, [groupedRowsByKey]);
+
+    const rowLookup = useMemo((): Map<string, GroupedStatisticTableRow> => {
+        const lookup = new Map<string, GroupedStatisticTableRow>();
+
+        groupedRowsByKey.forEach((rows, groupKey) => {
+            rows.forEach(row => {
+                lookup.set(getRowPinKey(groupKey, row.category), row);
+            });
+        });
+
+        return lookup;
+    }, [groupedRowsByKey]);
+
+    const rowGroupLookup = useMemo((): Map<string, string> => {
+        const lookup = new Map<string, string>();
+
+        groupedRowsByKey.forEach((rows, groupKey) => {
+            rows.forEach(row => {
+                lookup.set(getRowPinKey(groupKey, row.category), groupKey);
+            });
+        });
+
+        return lookup;
+    }, [groupedRowsByKey]);
+
+    const isRowSelected = useCallback(
+        (groupKey: string, rowPinKey: string): boolean => {
+            if (selectedGroups.has(groupKey)) {
+                return !deselectedRowsInSelectedGroups.has(rowPinKey);
+            }
+
+            return selectedRows.has(rowPinKey);
+        },
+        [deselectedRowsInSelectedGroups, selectedGroups, selectedRows],
+    );
 
     const controlIdBase = useId().replace(/:/g, '');
 
@@ -352,6 +454,172 @@ export default function MinecraftGroupedStatisticTable({
         });
     }, []);
 
+    const onToggleSelectedGroup = useCallback(
+        (groupKey: string): void => {
+            const groupRowKeys = rowKeysByGroup.get(groupKey) || [];
+            const selectedGroupRowCount = groupRowKeys.filter(rowKey => isRowSelected(groupKey, rowKey)).length;
+            const isGroupFullySelected = groupRowKeys.length > 0 && selectedGroupRowCount === groupRowKeys.length;
+
+            setSelectedGroups(previousSelectedGroups => {
+                const updated = new Set(previousSelectedGroups);
+
+                if (isGroupFullySelected) {
+                    updated.delete(groupKey);
+                } else {
+                    updated.add(groupKey);
+                }
+
+                return updated;
+            });
+
+            setSelectedRows(previousSelectedRows => {
+                const updated = new Set(previousSelectedRows);
+
+                groupRowKeys.forEach(rowKey => {
+                    updated.delete(rowKey);
+                });
+
+                return updated;
+            });
+
+            setDeselectedRowsInSelectedGroups(previousDeselectedRows => {
+                const updated = new Set(previousDeselectedRows);
+
+                groupRowKeys.forEach(rowKey => {
+                    updated.delete(rowKey);
+                });
+
+                return updated;
+            });
+        },
+        [isRowSelected, rowKeysByGroup],
+    );
+
+    const onToggleSelectedRow = useCallback(
+        (groupKey: string, rowCategory: string): void => {
+            const rowPinKey = getRowPinKey(groupKey, rowCategory);
+            const isGroupSelected = selectedGroups.has(groupKey);
+
+            if (isGroupSelected) {
+                setDeselectedRowsInSelectedGroups(previousDeselectedRows => {
+                    const updated = new Set(previousDeselectedRows);
+
+                    if (updated.has(rowPinKey)) {
+                        updated.delete(rowPinKey);
+                    } else {
+                        updated.add(rowPinKey);
+                    }
+
+                    return updated;
+                });
+
+                setSelectedRows(previousSelectedRows => {
+                    if (!previousSelectedRows.has(rowPinKey)) {
+                        return previousSelectedRows;
+                    }
+
+                    const updated = new Set(previousSelectedRows);
+                    updated.delete(rowPinKey);
+                    return updated;
+                });
+
+                return;
+            }
+
+            setSelectedRows(previousSelectedRows => {
+                const updated = new Set(previousSelectedRows);
+
+                if (updated.has(rowPinKey)) {
+                    updated.delete(rowPinKey);
+                } else {
+                    updated.add(rowPinKey);
+                }
+
+                return updated;
+            });
+
+            setDeselectedRowsInSelectedGroups(previousDeselectedRows => {
+                if (!previousDeselectedRows.has(rowPinKey)) {
+                    return previousDeselectedRows;
+                }
+
+                const updated = new Set(previousDeselectedRows);
+                updated.delete(rowPinKey);
+                return updated;
+            });
+        },
+        [selectedGroups],
+    );
+
+    const selectionSnapshot = useMemo((): MinecraftGroupedStatisticTableSelectionSnapshot => {
+        const resolvedRowsByKey = new Map<string, GroupedStatisticTableRow>();
+
+        selectedGroups.forEach(groupKey => {
+            (groupedRowsByKey.get(groupKey) || []).forEach(row => {
+                const rowKey = getRowPinKey(groupKey, row.category);
+
+                if (deselectedRowsInSelectedGroups.has(rowKey)) {
+                    return;
+                }
+
+                resolvedRowsByKey.set(rowKey, row);
+            });
+        });
+
+        selectedRows.forEach(rowKey => {
+            const rowGroupKey = rowGroupLookup.get(rowKey);
+            if (rowGroupKey && selectedGroups.has(rowGroupKey) && deselectedRowsInSelectedGroups.has(rowKey)) {
+                return;
+            }
+
+            const row = rowLookup.get(rowKey);
+            if (row) {
+                resolvedRowsByKey.set(rowKey, row);
+            }
+        });
+
+        const resolvedSelectedRows = Array.from(resolvedRowsByKey.entries())
+            .sort(([leftKey], [rightKey]) => leftKey.localeCompare(rightKey))
+            .map(([, row]) => row);
+
+        return {
+            selectedGroupKeys: Array.from(selectedGroups).sort((left, right) => left.localeCompare(right)),
+            selectedRowKeys: Array.from(resolvedRowsByKey.keys()).sort((left, right) => left.localeCompare(right)),
+            resolvedSelectedRows,
+        };
+    }, [deselectedRowsInSelectedGroups, groupedRowsByKey, rowGroupLookup, rowLookup, selectedGroups, selectedRows]);
+
+    useImperativeHandle(
+        ref,
+        () => ({
+            getSelectionSnapshot: () => selectionSnapshot,
+            clearSelection: () => {
+                setSelectedGroups(new Set());
+                setSelectedRows(new Set());
+                setDeselectedRowsInSelectedGroups(new Set());
+            },
+        }),
+        [selectionSnapshot],
+    );
+
+    const prevSelectionRowKeysRef = useRef<string[]>([]);
+    useEffect(() => {
+        if (!onSelectionChange) {
+            return;
+        }
+
+        const prev = prevSelectionRowKeysRef.current;
+        const curr = selectionSnapshot.selectedRowKeys;
+        const changed = prev.length !== curr.length || curr.some((key, index) => key !== prev[index]);
+
+        if (!changed) {
+            return;
+        }
+
+        prevSelectionRowKeysRef.current = curr;
+        onSelectionChange(selectionSnapshot);
+    }, [onSelectionChange, selectionSnapshot]);
+
     useEffect(() => {
         setSelectedSortOrder(defaultSortOrder);
     }, [defaultSortOrder]);
@@ -367,12 +635,10 @@ export default function MinecraftGroupedStatisticTable({
     useEffect(() => {
         const eventHandler = (event: StatisticUpdatedMessage): void => {
             setData(previousState => {
-                const isConsolidatedDataEvent =
-                    event.id === 'consolidated_data' &&
-                    event.children_string_values &&
-                    event.children_string_values.length > 0;
+                const isConsolidatedDataEvent = event.id === 'consolidated_data';
 
                 const categoryMap = new Map<string, GroupedStatisticTableRow>();
+                const observedCategories = new Set<string>();
 
                 if (!isConsolidatedDataEvent) {
                     previousState.forEach(previousRow => {
@@ -400,19 +666,38 @@ export default function MinecraftGroupedStatisticTable({
 
                 if (isConsolidatedDataEvent) {
                     processChildrenStringValues(
-                        event.children_string_values,
+                        event.children_string_values ?? [],
                         categoryMap,
                         valueLabels,
                         prettifyNames,
                         event.time || Date.now(),
+                        observedCategories,
                     );
+
+                    nonConsolidatedTickCounterRef.current = 0;
+                    nonConsolidatedLastEventTimeRef.current = undefined;
+                    nonConsolidatedLastSeenTickByCategoryRef.current.clear();
                 } else {
+                    const eventTime = Number.isFinite(event.time) ? event.time : undefined;
+                    const lastEventTime = nonConsolidatedLastEventTimeRef.current;
+
+                    if (eventTime === undefined) {
+                        nonConsolidatedTickCounterRef.current += 1;
+                    } else if (lastEventTime === undefined || lastEventTime !== eventTime) {
+                        nonConsolidatedTickCounterRef.current += 1;
+                        nonConsolidatedLastEventTimeRef.current = eventTime;
+                    }
+
+                    const currentTickCounter = Math.max(1, nonConsolidatedTickCounterRef.current);
+
                     const rawStats = statisticResolver(event, []);
 
                     rawStats.forEach(stat => {
                         if (!stat.category) {
                             return;
                         }
+
+                        observedCategories.add(stat.category);
 
                         const existing = categoryMap.get(stat.category);
                         if (existing) {
@@ -443,8 +728,33 @@ export default function MinecraftGroupedStatisticTable({
                             valueLabels,
                             prettifyNames,
                             event.time || Date.now(),
+                            observedCategories,
                         );
                     }
+
+                    const lastSeenByCategory = nonConsolidatedLastSeenTickByCategoryRef.current;
+
+                    observedCategories.forEach(category => {
+                        lastSeenByCategory.set(category, currentTickCounter);
+                    });
+
+                    categoryMap.forEach((_, rowCategory) => {
+                        if (observedCategories.has(rowCategory)) {
+                            return;
+                        }
+
+                        const lastSeenEvent = lastSeenByCategory.get(rowCategory);
+                        if (lastSeenEvent === undefined) {
+                            // Bootstrap rows that predate tick-based tracking without immediate removal.
+                            lastSeenByCategory.set(rowCategory, currentTickCounter);
+                            return;
+                        }
+
+                        if (currentTickCounter - lastSeenEvent >= NON_CONSOLIDATED_STALE_TICK_THRESHOLD) {
+                            categoryMap.delete(rowCategory);
+                            lastSeenByCategory.delete(rowCategory);
+                        }
+                    });
                 }
 
                 const newestData = Array.from(categoryMap.values());
@@ -502,7 +812,70 @@ export default function MinecraftGroupedStatisticTable({
 
             return changed ? updated : previousPinnedRows;
         });
+
+        setSelectedGroups(previousSelectedGroups => {
+            let changed = false;
+            const updated = new Set<string>();
+
+            previousSelectedGroups.forEach(groupKey => {
+                if (validGroupKeys.has(groupKey)) {
+                    updated.add(groupKey);
+                    return;
+                }
+
+                changed = true;
+            });
+
+            return changed ? updated : previousSelectedGroups;
+        });
+
+        setSelectedRows(previousSelectedRows => {
+            let changed = false;
+            const updated = new Set<string>();
+
+            previousSelectedRows.forEach(rowKey => {
+                if (validRowKeys.has(rowKey)) {
+                    updated.add(rowKey);
+                    return;
+                }
+
+                changed = true;
+            });
+
+            return changed ? updated : previousSelectedRows;
+        });
+
+        setDeselectedRowsInSelectedGroups(previousDeselectedRows => {
+            let changed = false;
+            const updated = new Set<string>();
+
+            previousDeselectedRows.forEach(rowKey => {
+                if (validRowKeys.has(rowKey)) {
+                    updated.add(rowKey);
+                    return;
+                }
+
+                changed = true;
+            });
+
+            return changed ? updated : previousDeselectedRows;
+        });
     }, [data, groupKeyResolver]);
+
+    useEffect(() => {
+        if (!selectionEnabled || !defaultSelectAllGroups || hasInitializedDefaultSelection) {
+            return;
+        }
+
+        if (rowKeysByGroup.size === 0) {
+            return;
+        }
+
+        setSelectedGroups(new Set(rowKeysByGroup.keys()));
+        setSelectedRows(new Set());
+        setDeselectedRowsInSelectedGroups(new Set());
+        setHasInitializedDefaultSelection(true);
+    }, [defaultSelectAllGroups, hasInitializedDefaultSelection, rowKeysByGroup, selectionEnabled]);
 
     const groupedData = useMemo((): GroupedStatisticTableGroup[] => {
         if (!isGroupedMode) {
@@ -699,11 +1072,12 @@ export default function MinecraftGroupedStatisticTable({
     const renderLeafRow = (row: GroupedStatisticTableRow, rowKey: string, groupKey: string): JSX.Element => {
         const rowPinKey = getRowPinKey(groupKey, row.category);
         const isPinned = pinnedRows.has(rowPinKey);
+        const isSelected = isRowSelected(groupKey, rowPinKey);
 
         return (
             <tr
                 key={rowKey}
-                className={`minecraft-grouped-statistic-child-row${isPinned ? ' minecraft-grouped-statistic-row-pinned' : ''}`}
+                className={`minecraft-grouped-statistic-child-row${isPinned ? ' minecraft-grouped-statistic-row-pinned' : ''}${isSelected ? ' minecraft-grouped-statistic-row-selected' : ''}`}
             >
                 <td className="minecraft-grouped-statistic-table-grid-pin">
                     <VSCodeCheckbox
@@ -712,6 +1086,15 @@ export default function MinecraftGroupedStatisticTable({
                         aria-label={isPinned ? `Unpin ${row.category}` : `Pin ${row.category}`}
                     />
                 </td>
+                {selectionEnabled && (
+                    <td className="minecraft-grouped-statistic-table-grid-select">
+                        <VSCodeCheckbox
+                            checked={isSelected}
+                            onClick={() => onToggleSelectedRow(groupKey, row.category)}
+                            aria-label={isSelected ? `Deselect ${row.category}` : `Select ${row.category}`}
+                        />
+                    </td>
+                )}
                 <td>
                     <span className="minecraft-grouped-statistic-child-key">{row.category}</span>
                 </td>
@@ -790,6 +1173,11 @@ export default function MinecraftGroupedStatisticTable({
                     <thead>
                         <tr>
                             <th className="minecraft-grouped-statistic-table-grid-pin" aria-label="Pinned"></th>
+                            {selectionEnabled && (
+                                <th className="minecraft-grouped-statistic-table-grid-select">
+                                    {selectionHeaderLabel}
+                                </th>
+                            )}
                             <th>{keyLabel}</th>
                             {valueLabels.map(label => (
                                 <th key={label} className="minecraft-grouped-statistic-table-grid-numeric">
@@ -809,10 +1197,18 @@ export default function MinecraftGroupedStatisticTable({
                                   const isExpanded = expandedGroups.has(group.expansionKey);
                                   const isGroupExplicitlyPinned = pinnedGroups.has(group.key);
                                   const isGroupPinned = isGroupExplicitlyPinned || group.isPinnedSection;
+                                  const groupRows = groupedRowsByKey.get(group.key) || [];
+                                  const selectedGroupRowCount = groupRows.filter(row =>
+                                      isRowSelected(group.key, getRowPinKey(group.key, row.category)),
+                                  ).length;
+                                  const isGroupSelected =
+                                      groupRows.length > 0 && selectedGroupRowCount === groupRows.length;
+                                  const isGroupSelectionIndeterminate =
+                                      selectedGroupRowCount > 0 && selectedGroupRowCount < groupRows.length;
                                   const rows: JSX.Element[] = [
                                       <tr
                                           key={`group-${group.expansionKey}-${groupIndex}`}
-                                          className={`minecraft-grouped-statistic-group-row${isGroupPinned ? ' minecraft-grouped-statistic-group-row-pinned' : ''}`}
+                                          className={`minecraft-grouped-statistic-group-row${isGroupPinned ? ' minecraft-grouped-statistic-group-row-pinned' : ''}${isGroupSelected ? ' minecraft-grouped-statistic-row-selected' : ''}`}
                                       >
                                           <td className="minecraft-grouped-statistic-table-grid-pin">
                                               <VSCodeCheckbox
@@ -830,6 +1226,20 @@ export default function MinecraftGroupedStatisticTable({
                                                   }
                                               />
                                           </td>
+                                          {selectionEnabled && (
+                                              <td className="minecraft-grouped-statistic-table-grid-select">
+                                                  <VSCodeCheckbox
+                                                      checked={isGroupSelected}
+                                                      indeterminate={isGroupSelectionIndeterminate}
+                                                      onClick={() => onToggleSelectedGroup(group.key)}
+                                                      aria-label={
+                                                          isGroupSelected
+                                                              ? `Deselect group ${group.key}`
+                                                              : `Select group ${group.key}`
+                                                      }
+                                                  />
+                                              </td>
+                                          )}
                                           <td>
                                               <button
                                                   type="button"
@@ -912,4 +1322,6 @@ export default function MinecraftGroupedStatisticTable({
             </div>
         </div>
     );
-}
+});
+
+export default MinecraftGroupedStatisticTable;

--- a/webview-ui/src/diagnostics_panel/prefabs/tabs/ClientEntitySystems.tsx
+++ b/webview-ui/src/diagnostics_panel/prefabs/tabs/ClientEntitySystems.tsx
@@ -406,7 +406,7 @@ const StatsTab: TabPrefab = {
                             title="Entity Timings"
                             showTitle={false}
                             selectionEnabled={selectionMode === 'filter'}
-                            selectionHeaderLabel="Focus"
+                            selectionHeaderLabel="Filter To"
                             onSelectionChange={selectionMode === 'filter' ? handleEntitySelectionChange : undefined}
                             keyLabel="Entity"
                             valueLabels={entityValueLabels}

--- a/webview-ui/src/diagnostics_panel/prefabs/tabs/ClientEntitySystems.tsx
+++ b/webview-ui/src/diagnostics_panel/prefabs/tabs/ClientEntitySystems.tsx
@@ -5,6 +5,8 @@ import { TabPrefab, TabPrefabDataSource, TabPrefabParams } from '../TabPrefab';
 import MinecraftGroupedStatisticTable, {
     MinecraftGroupedStatisticTableColumnAggregation,
     MinecraftGroupedStatisticTableDisplayMode,
+    MinecraftGroupedStatisticTableHandle,
+    MinecraftGroupedStatisticTableSelectionSnapshot,
     MinecraftGroupedStatisticTableSortOrder,
     MinecraftGroupedStatisticTableSortType,
 } from '../../controls/MinecraftGroupedStatisticTable';
@@ -16,10 +18,12 @@ import {
     useDebuggerRequestUpdates,
 } from '../../utilities/useDebuggerRequests';
 import { MultipleStatisticProvider, StatisticUpdatedMessage } from '../../StatisticProvider';
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { VSCodeButton, VSCodeDropdown, VSCodeOption } from '@vscode/webview-ui-toolkit/react';
 
 const START_ENTITY_SYSTEM_PROFILER_REQUEST = 'Start Entity System Profiler';
+const FILTER_MULTI_ENTITY_REQUEST = 'Filter Multi Entity System Profiler';
+const FILTER_SINGLE_ENTITY_REQUEST = 'Filter Single Entity System Profiler';
 
 const DEBUGGER_REQUEST_COMMANDS = [
     { command: START_ENTITY_SYSTEM_PROFILER_REQUEST, label: 'Start' },
@@ -30,6 +34,7 @@ const DEBUGGER_REQUEST_COMMANDS = [
 type TimingUnit = 'ns' | 'us' | 'ms';
 type EntityViewMode = 'flat' | 'grouped';
 type SystemViewMode = 'flat' | 'grouped';
+type EntitySelectionMode = 'force-all' | 'filter' | 'single-entity';
 
 const UNCATEGORIZED_SYSTEM_GROUP = 'INVALID CATEGORY';
 
@@ -127,12 +132,17 @@ const StatsTab: TabPrefab = {
     content: ({ selectedClient }: TabPrefabParams) => {
         useDebuggerRequestUpdates();
         const [lastRequestedCommand, setLastRequestedCommand] = useState<string>('');
-        const [clearResetEpoch, setClearResetEpoch] = useState(0);
         const [entityTimingUnit, setEntityTimingUnit] = useState<TimingUnit>('ms');
         const [systemTimingUnit, setSystemTimingUnit] = useState<TimingUnit>('us');
         const [entityViewMode, setEntityViewMode] = useState<EntityViewMode>('grouped');
         const [systemViewMode, setSystemViewMode] = useState<SystemViewMode>('grouped');
         const [systemCategoryLegendMap, setSystemCategoryLegendMap] = useState<Map<string, string>>(new Map());
+        const [selectionMode, setSelectionMode] = useState<EntitySelectionMode>('force-all');
+        const [availableEntities, setAvailableEntities] = useState<{ id: string; fullName: string }[]>([]);
+        const [selectedSingleEntityId, setSelectedSingleEntityId] = useState<string | undefined>(undefined);
+        const [filteredEntityCount, setFilteredEntityCount] = useState<number | undefined>(undefined);
+        const entityTimingsTableRef = useRef<MinecraftGroupedStatisticTableHandle | null>(null);
+        const isMountRef = useRef(true);
         const categoriesProvider = useMemo(() => {
             if (!selectedClient) {
                 return undefined;
@@ -140,6 +150,17 @@ const StatsTab: TabPrefab = {
 
             return new MultipleStatisticProvider({
                 statisticParentId: new RegExp(`${selectedClient}_client_ecs_categories`),
+            });
+        }, [selectedClient]);
+
+        const entityIdsProvider = useMemo(() => {
+            if (!selectedClient) {
+                return undefined;
+            }
+
+            return new MultipleStatisticProvider({
+                statisticIds: ['time_in_ns'],
+                statisticParentId: new RegExp(`${selectedClient}_client_ecs_entities`),
             });
         }, [selectedClient]);
 
@@ -173,7 +194,77 @@ const StatsTab: TabPrefab = {
             };
         }, [categoriesProvider, selectedClient]);
 
+        useEffect(() => {
+            setAvailableEntities([]);
+            setSelectedSingleEntityId(undefined);
+
+            if (!entityIdsProvider) {
+                return;
+            }
+
+            const seenIds = new Set<string>();
+
+            const eventHandler = (event: StatisticUpdatedMessage): void => {
+                const entityId = extractEntityId(event.group_name);
+                if (entityId && !seenIds.has(entityId)) {
+                    seenIds.add(entityId);
+                    setAvailableEntities(prev => [...prev, { id: entityId, fullName: event.group_name }]);
+                }
+            };
+
+            entityIdsProvider.registerWindowListener(window);
+            entityIdsProvider.addSubscriber(eventHandler);
+
+            return () => {
+                entityIdsProvider.removeSubscriber(eventHandler);
+                entityIdsProvider.unregisterWindowListener(window);
+            };
+        }, [entityIdsProvider]);
+
+        useEffect(() => {
+            if (isMountRef.current) {
+                isMountRef.current = false;
+                return;
+            }
+
+            entityTimingsTableRef.current?.clearSelection();
+            setSelectedSingleEntityId(undefined);
+            setFilteredEntityCount(undefined);
+
+            if (selectionMode === 'force-all') {
+                setLastRequestedCommand(START_ENTITY_SYSTEM_PROFILER_REQUEST);
+                sendDebuggerRequest(START_ENTITY_SYSTEM_PROFILER_REQUEST, { entityIds: [] });
+            }
+        }, [selectionMode]);
+
+        const handleEntitySelectionChange = useCallback(
+            (snapshot: MinecraftGroupedStatisticTableSelectionSnapshot): void => {
+                const entityIds = Array.from(
+                    new Set(
+                        snapshot.resolvedSelectedRows
+                            .map(row => extractEntityId(row.category))
+                            .filter((entityId): entityId is string => entityId !== undefined),
+                    ),
+                );
+
+                setFilteredEntityCount(entityIds.length);
+                setLastRequestedCommand(FILTER_MULTI_ENTITY_REQUEST);
+                sendDebuggerRequest(FILTER_MULTI_ENTITY_REQUEST, { entityIds });
+            },
+            [],
+        );
+
         const entityValueLabels = [getTimingColumnLabel(entityTimingUnit), 'Percent Of Total'];
+
+        const filteredEntityLabel = (() => {
+            if (selectionMode === 'single-entity') {
+                return selectedSingleEntityId ? 'Currently Filtered to 1 Entity' : 'Showing All Entities';
+            }
+            if (selectionMode === 'filter' && filteredEntityCount !== undefined && filteredEntityCount > 0) {
+                return `Currently Filtered to ${filteredEntityCount} ${filteredEntityCount === 1 ? 'Entity' : 'Entities'}`;
+            }
+            return 'Showing All Entities';
+        })();
 
         const lastResult: DebuggerRequestResultMessage | undefined = lastRequestedCommand
             ? getDebuggerRequestResult(lastRequestedCommand)
@@ -191,10 +282,6 @@ const StatsTab: TabPrefab = {
                                     key={command.command}
                                     disabled={inFlight}
                                     onClick={() => {
-                                        if (command.command === 'Clear Entity System Profiler') {
-                                            setClearResetEpoch(prev => prev + 1);
-                                        }
-
                                         setLastRequestedCommand(command.command);
                                         sendDebuggerRequest(command.command);
                                     }}
@@ -252,12 +339,75 @@ const StatsTab: TabPrefab = {
                                     </VSCodeDropdown>
                                 </div>
                             </div>
+                            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '10px', marginTop: '10px' }}>
+                                <div
+                                    className="dropdown-container"
+                                    style={{ flex: 0.5 }}
+                                    title={
+                                        'Select which entities to include in System profiling:\n' +
+                                        '\u2022 "All Entities" will display system information for every entity.\n' +
+                                        '\u2022 "Filter By Selection" allows you to select specific entities, and only show the System information for that selection.\n' +
+                                        '\u2022 "Filter to Single Entity" allows you to select one specific entity, and only display information for that selection. (This comes with some in-game performance benefits as we can narrow our profiling costs.)'
+                                    }
+                                >
+                                    <label htmlFor="ecs-entity-selection-mode" style={{ marginBottom: '5px' }}>
+                                        Entity Selection Mode <span style={{ opacity: 0.8 }}>🛈</span>
+                                    </label>
+                                    <VSCodeDropdown
+                                        id="ecs-entity-selection-mode"
+                                        style={{ width: '100%' }}
+                                        value={selectionMode}
+                                        onChange={(event: Event | React.FormEvent<HTMLElement>) => {
+                                            const target = event.target as HTMLSelectElement;
+                                            setSelectionMode(target.value as EntitySelectionMode);
+                                        }}
+                                    >
+                                        <VSCodeOption value="force-all">All Entities</VSCodeOption>
+                                        <VSCodeOption value="filter">Filter By Selection</VSCodeOption>
+                                        <VSCodeOption value="single-entity">Filter to Single Entity</VSCodeOption>
+                                    </VSCodeDropdown>
+                                </div>
+                                {selectionMode === 'single-entity' && (
+                                    <div className="dropdown-container" style={{ flex: 0.5 }}>
+                                        <label htmlFor="ecs-single-entity-id" style={{ marginBottom: '5px' }}>
+                                            Entity
+                                        </label>
+                                        <VSCodeDropdown
+                                            id="ecs-single-entity-id"
+                                            style={{ width: '100%' }}
+                                            value={selectedSingleEntityId ?? ''}
+                                            onChange={(event: Event | React.FormEvent<HTMLElement>) => {
+                                                const target = event.target as HTMLSelectElement;
+                                                const entityId = target.value || undefined;
+                                                setSelectedSingleEntityId(entityId);
+                                                if (entityId) {
+                                                    setLastRequestedCommand(FILTER_SINGLE_ENTITY_REQUEST);
+                                                    sendDebuggerRequest(FILTER_SINGLE_ENTITY_REQUEST, {
+                                                        entityIds: [entityId],
+                                                    });
+                                                }
+                                            }}
+                                        >
+                                            <VSCodeOption value="">-- select an entity --</VSCodeOption>
+                                            {availableEntities.map(({ id, fullName }) => (
+                                                <VSCodeOption key={id} value={id}>
+                                                    {fullName}
+                                                </VSCodeOption>
+                                            ))}
+                                        </VSCodeDropdown>
+                                    </div>
+                                )}
+                            </div>
                         </div>
 
                         <MinecraftGroupedStatisticTable
-                            key={`entity-timings-${entityViewMode}-${selectedClient}-${clearResetEpoch}`}
+                            ref={entityTimingsTableRef}
+                            key={`entity-timings-${entityViewMode}-${selectedClient}`}
                             title="Entity Timings"
                             showTitle={false}
+                            selectionEnabled={selectionMode === 'filter'}
+                            selectionHeaderLabel="Focus"
+                            onSelectionChange={selectionMode === 'filter' ? handleEntitySelectionChange : undefined}
                             keyLabel="Entity"
                             valueLabels={entityValueLabels}
                             displayMode={
@@ -289,30 +439,6 @@ const StatsTab: TabPrefab = {
                                     valueScalar: 1,
                                 }),
                             )}
-                            rowAction={{
-                                label: '🔍',
-                                headerLabel: 'Focus',
-                                width: '70px',
-                                disabled: () => isDebuggerRequestInFlight(START_ENTITY_SYSTEM_PROFILER_REQUEST),
-                                onClick: async row => {
-                                    const entityId = extractEntityId(row.category);
-                                    if (!entityId) {
-                                        return;
-                                    }
-
-                                    setLastRequestedCommand(START_ENTITY_SYSTEM_PROFILER_REQUEST);
-
-                                    const args = {
-                                        entityId,
-                                    };
-                                    sendDebuggerRequest(START_ENTITY_SYSTEM_PROFILER_REQUEST, args);
-
-                                    while (isDebuggerRequestInFlight(START_ENTITY_SYSTEM_PROFILER_REQUEST)) {
-                                        await new Promise(resolve => setTimeout(resolve, 100));
-                                    }
-                                    setClearResetEpoch(prev => prev + 1);
-                                },
-                            }}
                             nonConsolidatedColumnResolver={event => resolveEcsColumn(event.id)}
                             valueFormatter={(value, columnIndex) => {
                                 // Timing column
@@ -331,6 +457,11 @@ const StatsTab: TabPrefab = {
                     <div style={{ flex: 1, marginRight: '5px' }}>
                         <div style={{ marginTop: '10px', marginBottom: '10px' }}>
                             <h2>System Timings</h2>
+                            <div className="minecraft-entity-system-count-badge">
+                                <span className="minecraft-entity-system-count-badge-content">
+                                    {filteredEntityLabel}
+                                </span>
+                            </div>
                             <div style={{ display: 'flex', flexWrap: 'wrap', gap: '10px' }}>
                                 <div className="dropdown-container">
                                     <label htmlFor="ecs-system-timing-unit" style={{ marginBottom: '5px' }}>
@@ -368,7 +499,7 @@ const StatsTab: TabPrefab = {
                             </div>
                         </div>
                         <MinecraftGroupedStatisticTable
-                            key={`system-timings-${systemViewMode}-${selectedClient}-${clearResetEpoch}`}
+                            key={`system-timings-${systemViewMode}-${selectedClient}`}
                             title="System Timings"
                             showTitle={false}
                             keyLabel="System"

--- a/webview-ui/src/diagnostics_panel/prefabs/tabs/ClientEntitySystems.tsx
+++ b/webview-ui/src/diagnostics_panel/prefabs/tabs/ClientEntitySystems.tsx
@@ -385,6 +385,12 @@ const StatsTab: TabPrefab = {
                                                     sendDebuggerRequest(FILTER_SINGLE_ENTITY_REQUEST, {
                                                         entityIds: [entityId],
                                                     });
+                                                } else {
+                                                    // If we don't have a valid entity selected, still send the event with no id's
+                                                    setLastRequestedCommand(FILTER_SINGLE_ENTITY_REQUEST);
+                                                    sendDebuggerRequest(FILTER_SINGLE_ENTITY_REQUEST, {
+                                                        entityIds: [],
+                                                    });
                                                 }
                                             }}
                                         >

--- a/webview-ui/src/diagnostics_panel/prefabs/tabs/ClientEntitySystems.tsx
+++ b/webview-ui/src/diagnostics_panel/prefabs/tabs/ClientEntitySystems.tsx
@@ -360,6 +360,13 @@ const StatsTab: TabPrefab = {
                                         onChange={(event: Event | React.FormEvent<HTMLElement>) => {
                                             const target = event.target as HTMLSelectElement;
                                             setSelectionMode(target.value as EntitySelectionMode);
+                                            if (target.value !== 'single-entity') {
+                                                // send a new start event to get back to a clean state
+                                                setLastRequestedCommand(START_ENTITY_SYSTEM_PROFILER_REQUEST);
+                                                sendDebuggerRequest(START_ENTITY_SYSTEM_PROFILER_REQUEST, {
+                                                    entityIds: [],
+                                                });
+                                            }
                                         }}
                                     >
                                         <VSCodeOption value="force-all">All Entities</VSCodeOption>


### PR DESCRIPTION
This change adds support for different filtering modes of entities in the `Client - Entity Systems` tab.

You now have the following options:
- All Entities
    - simply displays all entities and all system timings
- Filter By Selection
    - this allows the user to select which entities they want to filter to, and only system timings for those entities will populate
- Filter to Single Entity
    - this allows the user to choose one single entity, which uses a more performant path for retrieving the system timings

In support of this, we added multi selection (similar to our groupings) and the ability to query which rows are selected to the `MinecraftGroupedStatisticTable`. 

The Entity Systems tab can then use this to make requests to the Client providing the relevant Entity ID's and request type.

In addition to this change we removed the old `clearEpoch` logic for handling resetting of the table, and instead as new events come in we phase out stale data. 

https://github.com/user-attachments/assets/9a6baee4-6250-4653-9442-ebc42df25194