### PR TITLE
feat: Create a banner for displaying debuggerRequestResults in a unified and styled fashion

### DIFF
--- a/webview-ui/src/diagnostics_panel/App.css
+++ b/webview-ui/src/diagnostics_panel/App.css
@@ -72,6 +72,79 @@ main {
   margin-bottom: 2px;
 }
 
+.minecraft-debugger-request-result {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 10px 12px;
+  border: 1px solid transparent;
+  border-radius: 8px;
+}
+
+.minecraft-debugger-request-result__badge {
+  flex: 0 0 auto;
+  border-radius: 999px;
+  padding: 2px 8px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.minecraft-debugger-request-result__content {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.minecraft-debugger-request-result__title {
+  font-weight: 600;
+}
+
+.minecraft-debugger-request-result__message {
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+
+.minecraft-debugger-request-result--neutral {
+  background: color-mix(in srgb, var(--vscode-editorInfo-foreground) 12%, var(--vscode-editor-background));
+  border-color: color-mix(in srgb, var(--vscode-editorInfo-foreground) 28%, var(--vscode-editor-background));
+}
+
+.minecraft-debugger-request-result--neutral .minecraft-debugger-request-result__badge {
+  background: color-mix(in srgb, var(--vscode-editorInfo-foreground) 18%, var(--vscode-editor-background));
+  color: var(--vscode-editorInfo-foreground);
+}
+
+.minecraft-debugger-request-result--success {
+  background: color-mix(in srgb, var(--vscode-charts-green) 14%, var(--vscode-editor-background));
+  border-color: color-mix(in srgb, var(--vscode-charts-green) 32%, var(--vscode-editor-background));
+}
+
+.minecraft-debugger-request-result--success .minecraft-debugger-request-result__badge,
+.minecraft-debugger-request-result--success .minecraft-debugger-request-result__title {
+  color: var(--vscode-charts-green);
+}
+
+.minecraft-debugger-request-result--success .minecraft-debugger-request-result__badge {
+  background: color-mix(in srgb, var(--vscode-charts-green) 22%, var(--vscode-editor-background));
+}
+
+.minecraft-debugger-request-result--error {
+  background: color-mix(in srgb, var(--vscode-editorError-foreground) 14%, var(--vscode-editor-background));
+  border-color: color-mix(in srgb, var(--vscode-editorError-foreground) 32%, var(--vscode-editor-background));
+}
+
+.minecraft-debugger-request-result--error .minecraft-debugger-request-result__badge,
+.minecraft-debugger-request-result--error .minecraft-debugger-request-result__title {
+  color: var(--vscode-editorError-foreground);
+}
+
+.minecraft-debugger-request-result--error .minecraft-debugger-request-result__badge {
+  background: color-mix(in srgb, var(--vscode-editorError-foreground) 22%, var(--vscode-editor-background));
+}
+
 .minecraft-statistic-stacked-line-chart-figure {
   max-width: initial;
 }

--- a/webview-ui/src/diagnostics_panel/App.css
+++ b/webview-ui/src/diagnostics_panel/App.css
@@ -72,6 +72,27 @@ main {
   margin-bottom: 2px;
 }
 
+.stat-group-selection-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.stat-group-selection-help {
+  margin: 8px 0px 2px 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  border-radius: 999px;
+  border: 1px solid var(--vscode-descriptionForeground);
+  color: var(--vscode-descriptionForeground);
+  font-size: 10px;
+  font-weight: 700;
+  cursor: help;
+}
+
 .minecraft-debugger-request-result {
   display: flex;
   align-items: flex-start;

--- a/webview-ui/src/diagnostics_panel/App.tsx
+++ b/webview-ui/src/diagnostics_panel/App.tsx
@@ -47,6 +47,10 @@ const onRunCommand = (command: string) => {
     vscode.postMessage({ type: 'run-minecraft-command', command: command });
 };
 
+const CLIENT_SELECTION_HELP_TOOLTIP =
+    "If you're not seeing your player here, you may need to enable diagnostic collection.\n" +
+    'Please enable "Creator > Script Diagnostics Settings > Enable Client Diagnostics" from within the game settings.';
+
 function App() {
     const sortedTabPrefabs = [...tabPrefabs].sort((a, b) => a.name.localeCompare(b.name));
     const [selectedPlugin, setSelectedPlugin] = useState<string>('');
@@ -62,8 +66,6 @@ function App() {
     const handleClientSelection = useCallback((clientSelectionId: string) => {
         setSelectedClient(() => clientSelectionId);
     }, []);
-
-
 
     useEffect(() => {
         const handleMessage = (event: MessageEvent) => {
@@ -112,13 +114,18 @@ function App() {
                     {sortedTabPrefabs.map((tabPrefab, index) => (
                         <div
                             key={`view-${index}`}
-                            style={{ display: currentTab === `tab-${index}` ? 'flex' : 'none', flexDirection: 'column', flex: 1 }}
+                            style={{
+                                display: currentTab === `tab-${index}` ? 'flex' : 'none',
+                                flexDirection: 'column',
+                                flex: 1,
+                            }}
                         >
                             {tabPrefab.dataSource === TabPrefabDataSource.Client ? (
                                 <StatGroupSelectionBox
                                     labelName="Client"
                                     statParentId="client_stats"
                                     onChange={handleClientSelection}
+                                    helpTooltip={CLIENT_SELECTION_HELP_TOOLTIP}
                                 />
                             ) : (
                                 <div />
@@ -132,10 +139,7 @@ function App() {
                             ) : (
                                 <div />
                             )}
-                            <TabView
-                                tabPrefab={tabPrefab}
-                                params={{ selectedClient, selectedPlugin, onRunCommand }}
-                            />
+                            <TabView tabPrefab={tabPrefab} params={{ selectedClient, selectedPlugin, onRunCommand }} />
                         </div>
                     ))}
                 </div>

--- a/webview-ui/src/diagnostics_panel/controls/DebuggerRequestResult.tsx
+++ b/webview-ui/src/diagnostics_panel/controls/DebuggerRequestResult.tsx
@@ -1,5 +1,7 @@
+// Copyright (C) Microsoft Corporation.  All rights reserved.
+
 import type { ReactNode } from 'react';
-import type { DebuggerRequestResultMessage } from './useDebuggerRequests';
+import type { DebuggerRequestResultMessage } from '../utilities/useDebuggerRequests';
 
 type DebuggerRequestResultTone = 'error' | 'success' | 'neutral';
 
@@ -49,10 +51,6 @@ function getDebuggerRequestResultViewModel(lastResult?: DebuggerRequestResultMes
     };
 }
 
-export function lastResultToUserFriendlyString(lastResult: DebuggerRequestResultMessage): string {
-    return getDebuggerRequestResultViewModel(lastResult).message;
-}
-
 function renderMultilineMessage(message: string): ReactNode[] {
     return message
         .replace(/\r\n/g, '\n')
@@ -77,7 +75,9 @@ export function DebuggerRequestResultBanner({
             <div className="minecraft-debugger-request-result__badge">Client</div>
             <div className="minecraft-debugger-request-result__content">
                 <div className="minecraft-debugger-request-result__title">{viewModel.title}</div>
-                <div className="minecraft-debugger-request-result__message">{renderMultilineMessage(viewModel.message)}</div>
+                <div className="minecraft-debugger-request-result__message">
+                    {renderMultilineMessage(viewModel.message)}
+                </div>
             </div>
         </div>
     );

--- a/webview-ui/src/diagnostics_panel/controls/StatGroupSelectionBox.tsx
+++ b/webview-ui/src/diagnostics_panel/controls/StatGroupSelectionBox.tsx
@@ -7,6 +7,7 @@ type SelectionBoxProps = {
     labelName: string;
     statParentId: string;
     onChange: (selectedGroupId: string) => void;
+    helpTooltip?: string;
 };
 
 interface StatGroupEntry {
@@ -14,7 +15,7 @@ interface StatGroupEntry {
     name: string;
 }
 
-export function StatGroupSelectionBox({ labelName, statParentId, onChange }: SelectionBoxProps) {
+export function StatGroupSelectionBox({ labelName, statParentId, onChange, helpTooltip }: SelectionBoxProps) {
     // the groups directly under the 'statParentId'
     const [groups, setGroup] = useState<StatGroupEntry[]>([]);
     const [selectedGroupId, setSelectedGroupId] = useState<string | undefined>(undefined);
@@ -24,11 +25,11 @@ export function StatGroupSelectionBox({ labelName, statParentId, onChange }: Sel
             const target = e.target as HTMLSelectElement;
             onChange(groups[target.selectedIndex].id);
         },
-        [groups]
+        [groups],
     );
 
     useEffect(() => {
-        onChange(selectedGroupId || "");
+        onChange(selectedGroupId || '');
     }, [selectedGroupId]);
 
     //draws chart
@@ -70,12 +71,17 @@ export function StatGroupSelectionBox({ labelName, statParentId, onChange }: Sel
 
     return (
         <div className="dropdown-container">
-            <label htmlFor="my-dropdown">{labelName}</label>
+            <label htmlFor="my-dropdown" className="stat-group-selection-label">
+                <span>{labelName}</span>
+                {helpTooltip && (
+                    <span className="stat-group-selection-help" title={helpTooltip} aria-label={`${labelName} help`}>
+                        ?
+                    </span>
+                )}
+            </label>
             <VSCodeDropdown id="my-dropdown" onChange={_onChange} disabled={groups.length === 0}>
                 {(groups ?? []).map(option => (
-                    <VSCodeOption key={option.id}>
-                        {option.name}
-                    </VSCodeOption>
+                    <VSCodeOption key={option.id}>{option.name}</VSCodeOption>
                 ))}
             </VSCodeDropdown>
         </div>

--- a/webview-ui/src/diagnostics_panel/prefabs/tabs/ClientCPUProfiler.tsx
+++ b/webview-ui/src/diagnostics_panel/prefabs/tabs/ClientCPUProfiler.tsx
@@ -9,26 +9,13 @@ import {
     sendDebuggerRequest,
     useDebuggerRequestUpdates,
 } from '../../utilities/useDebuggerRequests';
+import { DebuggerRequestResultBanner } from '../../utilities/debuggerRequestResult';
 import { VSCodeButton } from '@vscode/webview-ui-toolkit/react';
 
 const DEBUGGER_REQUEST_COMMANDS = [
     { command: 'Start CPU Profiler', label: 'Start' },
     { command: 'Stop CPU Profiler', label: 'Stop' },
 ];
-
-function lastResultToUserFriendlyString(lastResult: DebuggerRequestResultMessage): string {
-    if (lastResult.error) {
-        return `Error: ${lastResult.error}`;
-    } else if (lastResult.response) {
-        if (lastResult.response.success) {
-            return `${lastResult.response.response_message}`;
-        } else {
-            return `Failed: ${lastResult.response.response_message}`;
-        }
-    } else {
-        return 'Press Start to Begin Profiling';
-    }
-}
 
 function isWhiskerEvent(event: StatisticUpdatedMessage): boolean {
     return event.group === 'low' || event.group === 'mid' || event.group === 'high' || event.group === 'indents';
@@ -76,11 +63,7 @@ const StatsTab: TabPrefab = {
                             );
                         })}
                         <div style={{ marginTop: '20px' }}>
-                            <text style={{ fontStyle: 'italic' }}>
-                                {lastResult
-                                    ? lastResultToUserFriendlyString(lastResult)
-                                    : 'Press Start to Begin Profiling'}
-                            </text>
+                            <DebuggerRequestResultBanner lastResult={lastResult} />
                         </div>
                     </div>
                 </div>

--- a/webview-ui/src/diagnostics_panel/prefabs/tabs/ClientCPUProfiler.tsx
+++ b/webview-ui/src/diagnostics_panel/prefabs/tabs/ClientCPUProfiler.tsx
@@ -9,7 +9,7 @@ import {
     sendDebuggerRequest,
     useDebuggerRequestUpdates,
 } from '../../utilities/useDebuggerRequests';
-import { DebuggerRequestResultBanner } from '../../utilities/debuggerRequestResult';
+import { DebuggerRequestResultBanner } from '../../controls/DebuggerRequestResult';
 import { VSCodeButton } from '@vscode/webview-ui-toolkit/react';
 
 const DEBUGGER_REQUEST_COMMANDS = [

--- a/webview-ui/src/diagnostics_panel/prefabs/tabs/ClientEntitySystems.tsx
+++ b/webview-ui/src/diagnostics_panel/prefabs/tabs/ClientEntitySystems.tsx
@@ -17,6 +17,7 @@ import {
     sendDebuggerRequest,
     useDebuggerRequestUpdates,
 } from '../../utilities/useDebuggerRequests';
+import { DebuggerRequestResultBanner } from '../../utilities/debuggerRequestResult';
 import { MultipleStatisticProvider, StatisticUpdatedMessage } from '../../StatisticProvider';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { VSCodeButton, VSCodeDropdown, VSCodeOption } from '@vscode/webview-ui-toolkit/react';
@@ -110,20 +111,6 @@ function resolveSystemCategoryGroupKey(fullName: string, systemCategoryLegendMap
     const index = indexAndBracket ? indexAndBracket.split(')')[0].trim() : undefined;
     // Then lookup the category name from the legend map if it exists
     return index ? systemCategoryLegendMap.get(index) || UNCATEGORIZED_SYSTEM_GROUP : UNCATEGORIZED_SYSTEM_GROUP;
-}
-
-function lastResultToUserFriendlyString(lastResult: DebuggerRequestResultMessage): string {
-    if (lastResult.error) {
-        return `Error: ${lastResult.error}`;
-    } else if (lastResult.response) {
-        if (lastResult.response.success) {
-            return `${lastResult.response.response_message}`;
-        } else {
-            return `Failed: ${lastResult.response.response_message}`;
-        }
-    } else {
-        return 'Press Start to Begin Profiling';
-    }
 }
 
 const StatsTab: TabPrefab = {
@@ -292,11 +279,7 @@ const StatsTab: TabPrefab = {
                             );
                         })}
                         <div style={{ marginTop: '20px' }}>
-                            <text style={{ fontStyle: 'italic' }}>
-                                {lastResult
-                                    ? lastResultToUserFriendlyString(lastResult)
-                                    : 'Press Start to Begin Profiling'}
-                            </text>
+                            <DebuggerRequestResultBanner lastResult={lastResult} />
                         </div>
                     </div>
                 </div>

--- a/webview-ui/src/diagnostics_panel/prefabs/tabs/ClientEntitySystems.tsx
+++ b/webview-ui/src/diagnostics_panel/prefabs/tabs/ClientEntitySystems.tsx
@@ -17,7 +17,7 @@ import {
     sendDebuggerRequest,
     useDebuggerRequestUpdates,
 } from '../../utilities/useDebuggerRequests';
-import { DebuggerRequestResultBanner } from '../../utilities/debuggerRequestResult';
+import { DebuggerRequestResultBanner } from '../../controls/DebuggerRequestResult';
 import { MultipleStatisticProvider, StatisticUpdatedMessage } from '../../StatisticProvider';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { VSCodeButton, VSCodeDropdown, VSCodeOption } from '@vscode/webview-ui-toolkit/react';

--- a/webview-ui/src/diagnostics_panel/utilities/debuggerRequestResult.tsx
+++ b/webview-ui/src/diagnostics_panel/utilities/debuggerRequestResult.tsx
@@ -1,0 +1,84 @@
+import type { ReactNode } from 'react';
+import type { DebuggerRequestResultMessage } from './useDebuggerRequests';
+
+type DebuggerRequestResultTone = 'error' | 'success' | 'neutral';
+
+type DebuggerRequestResultViewModel = {
+    tone: DebuggerRequestResultTone;
+    title: string;
+    message: string;
+};
+
+function getDebuggerRequestResultViewModel(lastResult?: DebuggerRequestResultMessage): DebuggerRequestResultViewModel {
+    if (!lastResult) {
+        return {
+            tone: 'neutral',
+            title: 'Waiting for client response',
+            message: 'Press Start to Begin Profiling',
+        };
+    }
+
+    if (lastResult.error) {
+        return {
+            tone: 'error',
+            title: 'Client error',
+            message: `Error: ${lastResult.error}`,
+        };
+    }
+
+    if (lastResult.response?.success) {
+        return {
+            tone: 'success',
+            title: 'Client success',
+            message: lastResult.response.response_message ?? 'Success',
+        };
+    }
+
+    if (lastResult.response) {
+        return {
+            tone: 'error',
+            title: 'Client failure',
+            message: `Failed: ${lastResult.response.response_message}`,
+        };
+    }
+
+    return {
+        tone: 'neutral',
+        title: 'Waiting for client response',
+        message: 'Press Start to Begin Profiling',
+    };
+}
+
+export function lastResultToUserFriendlyString(lastResult: DebuggerRequestResultMessage): string {
+    return getDebuggerRequestResultViewModel(lastResult).message;
+}
+
+function renderMultilineMessage(message: string): ReactNode[] {
+    return message
+        .replace(/\r\n/g, '\n')
+        .split('\n')
+        .map((line, index) => (
+            <span key={`${index}-${line}`}>
+                {index > 0 && <br />}
+                {line}
+            </span>
+        ));
+}
+
+export function DebuggerRequestResultBanner({
+    lastResult,
+}: {
+    lastResult?: DebuggerRequestResultMessage;
+}): JSX.Element {
+    const viewModel = getDebuggerRequestResultViewModel(lastResult);
+
+    return (
+        <div className={`minecraft-debugger-request-result minecraft-debugger-request-result--${viewModel.tone}`}>
+            <div className="minecraft-debugger-request-result__badge">Client</div>
+            <div className="minecraft-debugger-request-result__content">
+                <div className="minecraft-debugger-request-result__title">{viewModel.title}</div>
+                <div className="minecraft-debugger-request-result__message">{renderMultilineMessage(viewModel.message)}</div>
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
This change makes the result message rendering unified between tabs (currently the Entity Systems profiler and the CPU profiler).

It also adds styling to make the errors/success cases more apparent. It also adds support for multiline messages.

Some examples:
<img width="1587" height="269" alt="error_bubble" src="https://github.com/user-attachments/assets/4df9cc20-df38-4771-b0e3-1e513f208b28" />
<img width="1594" height="425" alt="neutral_bubble" src="https://github.com/user-attachments/assets/916ff24a-9c9d-409a-9abf-31bdf9cf5343" />
<img width="1612" height="253" alt="success_bubble" src="https://github.com/user-attachments/assets/ef12fbcc-87be-49b4-baf0-3270ec458047" />
