### PR TITLE
fix: Add %appdata% resolution support for debugger config

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ CheckNetIsolation.exe LoopbackExempt -a -p=S-1-15-2-424268864-5579737-879501358-
 
 #### Open Visual Studio Code within your development_behavior_packs folder
 
-In order for the debugger to know where to find your source JavaScript or TypeScript files, you'll need to specifically open up a window of Visual Studio Code relative to the behavior pack where your JavaScript or TypeScript source files are. This may be inside of Minecraft's development_behavior_packs folder (e.g., `localappdata%\Packages\Microsoft.MinecraftUWP_8wekyb3d8bbwe\LocalState\games\com.mojang\development_behavior_packs`) - or you may have your source code located in a separate folder (e.g., `c:\projects\myaddon`).
+In order for the debugger to know where to find your source JavaScript or TypeScript files, you'll need to specifically open up a window of Visual Studio Code relative to the behavior pack where your JavaScript or TypeScript source files are. This may be inside of Minecraft's development_behavior_packs folder (e.g., `%appdata%\Minecraft Bedrock\Users\Shared\games\com.mojang`) - or you may have your source code located in a separate folder (e.g., `c:\projects\myaddon`).
 
 Open up a Visual Studio Code window pointed at the folder with your add-on script source.
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -176,7 +176,7 @@ export class Session extends DebugSession implements IDebuggeeMessageSender {
 
     // Use this to register new events that are handled from the debugee (Minecraft)
     // For example you want to send new arbitary data to the debugger that doesn't fit into the existing event types (such as a live stat)
-    // then you can create a new event type in protocol-events.ts, have Minecraft send that event with the new data, and then register a handler 
+    // then you can create a new event type in protocol-events.ts, have Minecraft send that event with the new data, and then register a handler
     // for that event here to handle the incoming data and do something with it (e.g. update the home view, send a notification, etc).
     private registerServerEvents() {
         this._eventRegistry.register(IncomingEventType.Stopped, (msg: StoppedEventMessage) => {
@@ -420,12 +420,17 @@ export class Session extends DebugSession implements IDebuggeeMessageSender {
 
     protected resolveEnvironmentVariables(args: IAttachRequestArguments): void {
         const localAppDataDir = process.env.LOCALAPPDATA || '';
+        const appDataDir = process.env.APPDATA || '';
 
         for (const key of Object.keys(args)) {
             //if the value is a string and starts with %localappdata%, replace it with the actual path to AppData\Local
             const value = args[key as keyof IAttachRequestArguments];
             if (typeof value === 'string' && value.toLowerCase().startsWith('%localappdata%')) {
                 (args as any)[key] = path.join(localAppDataDir, value.substring('%localappdata%'.length));
+            }
+            //replace %appdata% with the actual path to AppData\Roaming
+            if (typeof value === 'string' && value.toLowerCase().startsWith('%appdata%')) {
+                (args as any)[key] = path.join(appDataDir, value.substring('%appdata%'.length));
             }
         }
     }


### PR DESCRIPTION
- Adds a resolution for `%appdata%` in launch.json to the `appdata/roaming` path which GDK lives under.
- Updates readme to point to the GDK `development_behavior_packs` folder instead of UWP
