### PR TITLE
feat: Stack the Systems view below the Entity view if the horizontal width shrinks too much

### DIFF
--- a/webview-ui/src/diagnostics_panel/App.css
+++ b/webview-ui/src/diagnostics_panel/App.css
@@ -361,6 +361,18 @@ main {
   text-align: right;
 }
 
+.minecraft-entity-systems-tables-container {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  width: 100%;
+}
+
+.minecraft-entity-systems-table-wrapper {
+  flex: 1;
+  min-width: 550px;
+}
+
 .minecraft-entity-system-count-badge {
   display: flex;
   align-items: center;

--- a/webview-ui/src/diagnostics_panel/prefabs/tabs/ClientEntitySystems.tsx
+++ b/webview-ui/src/diagnostics_panel/prefabs/tabs/ClientEntitySystems.tsx
@@ -441,8 +441,8 @@ const StatsTab: TabPrefab = {
                                 )}
                             </div>
                         </div>
-                        <div style={{ flexDirection: 'row', display: 'flex', width: '100%' }}>
-                            <div style={{ flex: 1, marginRight: '5px' }}>
+                        <div className="minecraft-entity-systems-tables-container">
+                            <div className="minecraft-entity-systems-table-wrapper">
                                 <div style={{ marginTop: '10px', marginBottom: '10px' }}>
                                     <div style={{ display: 'flex', alignItems: 'center', gap: '16px' }}>
                                         <h2>Entity Timings</h2>


### PR DESCRIPTION
This change allows the Systems view to stack below the Entity view if the horizontal width gets too small.

Previously they stayed side by side, causing the text to become near unreadable. There are workflows where you want Minecraft on one half your screen and the debugger on the other, so this helps achieve that flow more easily. 


https://github.com/user-attachments/assets/30a4fd39-e4bc-4086-9123-883f9d70e6ac

