### PR TITLE
fix: Fixing debugger crash with breakpoints

### DIFF
--- a/src/protocol-events.ts
+++ b/src/protocol-events.ts
@@ -179,16 +179,9 @@ export interface ResumeMessage {
     type: OutgoingEventType.Resume;
 }
 
-export interface RequestLegacyMessage {
-    type: OutgoingEventType.Request;
-    request: { request_seq: number; command: string; args: unknown };
-}
-
 export interface RequestMessage {
     type: OutgoingEventType.Request;
-    request_seq: number;
-    command: string;
-    args: unknown;
+    request: { request_seq: number; command: string; args: unknown };
 }
 
 export interface BreakpointsLegacyMessage {
@@ -228,7 +221,6 @@ export type OutgoingDebuggeeMessage =
     | StopProfilerMessage
     | StopOnExceptionMessage
     | ResumeMessage
-    | RequestLegacyMessage
     | RequestMessage
     | BreakpointsLegacyMessage
     | BreakpointsMessage

--- a/src/session.ts
+++ b/src/session.ts
@@ -384,7 +384,6 @@ export class Session extends DebugSession implements IDebuggeeMessageSender {
         args: IAttachRequestArguments,
     ): Promise<void> {
         this.closeSession();
-        this._statsProvider.clearSchema();
 
         this.resolveEnvironmentVariables(args);
 
@@ -878,7 +877,6 @@ export class Session extends DebugSession implements IDebuggeeMessageSender {
     private terminateSession(reason: string, logLevel: LogLevel = LogLevel.Log) {
         this.closeServer();
         this.closeSession();
-        this._statsProvider.clearSchema();
 
         this._connected = false;
         this._clientProtocolVersion = ProtocolVersion._Unknown;

--- a/src/session.ts
+++ b/src/session.ts
@@ -58,7 +58,6 @@ import {
     StoppedEventMessage,
     ThreadEventMessage,
     DebuggeeResponseEnvelope,
-    RequestLegacyMessage,
     DiagnosticsDescriptorMessage,
 } from './protocol-events';
 import { SourceMaps } from './source-maps';
@@ -385,6 +384,7 @@ export class Session extends DebugSession implements IDebuggeeMessageSender {
         args: IAttachRequestArguments,
     ): Promise<void> {
         this.closeSession();
+        this._statsProvider.clearSchema();
 
         this.resolveEnvironmentVariables(args);
 
@@ -878,6 +878,7 @@ export class Session extends DebugSession implements IDebuggeeMessageSender {
     private terminateSession(reason: string, logLevel: LogLevel = LogLevel.Log) {
         this.closeServer();
         this.closeSession();
+        this._statsProvider.clearSchema();
 
         this._connected = false;
         this._clientProtocolVersion = ProtocolVersion._Unknown;
@@ -921,27 +922,16 @@ export class Session extends DebugSession implements IDebuggeeMessageSender {
         this.sendDebuggeeMessage(this.makeRequestPayload(requestSeq, response.command, args));
     }
 
-    private makeRequestPayload(requestSeq: number, responseCommand: string, args: unknown): RequestMessage | RequestLegacyMessage {
-        if (this._clientProtocolVersion >= ProtocolVersion.SupportCerealSerialization) {
-            const envelope: RequestMessage = {
-                type: OutgoingEventType.Request,
+    private makeRequestPayload(requestSeq: number, responseCommand: string, args: unknown): RequestMessage {
+        const envelope: RequestMessage = {
+            type: OutgoingEventType.Request,
+            request: {
                 request_seq: requestSeq,
                 command: responseCommand,
                 args,
-            };
-            return envelope;
-        }
-        else {
-            const envelope: RequestLegacyMessage = {
-                type: OutgoingEventType.Request,
-                request: {
-                    request_seq: requestSeq,
-                    command: responseCommand,
-                    args,
-                },
-            };
-            return envelope;
-        }
+            },
+        };
+        return envelope;
     }
 
     public sendDebuggeeMessage(envelope: OutgoingDebuggeeMessage): void {


### PR DESCRIPTION
The RequestMessage is used by QuickJS and shouldn't have been changed to the newer protocol format where the data is inlined into the single object.